### PR TITLE
MODINVOICE-35 - Prevent modifications to invoice/invoice lines once status is "Approved" (Drools approach)

### DIFF
--- a/src/main/java/org/folio/invoices/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/invoices/utils/ErrorCodes.java
@@ -4,7 +4,8 @@ import org.folio.rest.jaxrs.model.Error;
 
 public enum ErrorCodes {
 
-  GENERIC_ERROR_CODE("genericError", "Generic error");
+  GENERIC_ERROR_CODE("genericError", "Generic error"),
+  PROHIBITED_FIELD_CHANGING("protectedFieldChanging", "Field can't be modified");
 
   private final String code;
   private final String description;

--- a/src/main/java/org/folio/invoices/utils/InvoiceLineProtectedFields.java
+++ b/src/main/java/org/folio/invoices/utils/InvoiceLineProtectedFields.java
@@ -1,0 +1,36 @@
+package org.folio.invoices.utils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public enum InvoiceLineProtectedFields {
+
+  ADJUSTMENTS("adjustments"),
+  ADJUSTMENTS_TOTAL("adjustmentsTotal"),
+  INVOICE_ID("invoiceId"),
+  INVOICE_LINE_NUMBER("invoiceLineNumber"),
+  PO_LINE_ID("poLineId"),
+  PRODUCT_ID("productId"),
+  PRODUCT_ID_TYPE("productIdType"),
+  QUANTITY("quantity"),
+  SUBSCRIPTION_INFO("subscriptionInfo"),
+  SUBSCRIPTION_START("subscriptionStart"),
+  SUBSCRIPTION_END("subscriptionEnd"),
+  TOTAL("total");
+
+
+  InvoiceLineProtectedFields(String field) {
+    this.field = field;
+  }
+
+  public String getFieldName() {
+    return field;
+  }
+
+  private String field;
+
+  public static List<String> getFieldNames() {
+    return Arrays.stream(InvoiceLineProtectedFields.values()).map(InvoiceLineProtectedFields::getFieldName).collect(Collectors.toList());
+  }
+}

--- a/src/main/java/org/folio/invoices/utils/InvoiceProtectedFields.java
+++ b/src/main/java/org/folio/invoices/utils/InvoiceProtectedFields.java
@@ -1,0 +1,40 @@
+package org.folio.invoices.utils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public enum InvoiceProtectedFields {
+
+  ADJUSTMENTS("adjustments"),
+  ADJUSTMENTS_TOTAL("adjustmentsTotal"),
+  APPROVED_BY("approvedBy"),
+  APPROVAL_DATE("approvalDate"),
+  CHK_SUBSCRIPTION_OVERLAP("chkSubscriptionOverlap"),
+  CURRENCY("currency"),
+  FOLIO_INVOICE_NO("folioInvoiceNo"),
+  INVOICE_DATE("invoiceDate"),
+  LOCK_TOTAL("lockTotal"),
+  PAYMENT_TERMS("paymentTerms"),
+  SOURCE("source"),
+  SUB_TOTAL("subTotal"),
+  TOTAL("total"),
+  VOUCHER_NUMBER("voucherNumber"),
+  PAYMENT_ID("paymentId"),
+  PO_NUMBERS("poNumbers"),
+  VENDOR_ID("vendorId");
+
+  InvoiceProtectedFields(String field) {
+    this.field = field;
+  }
+
+  public String getFieldName() {
+    return field;
+  }
+
+  private String field;
+
+  public static List<String> getFieldNames() {
+    return Arrays.stream(InvoiceProtectedFields.values()).map(InvoiceProtectedFields::getFieldName).collect(Collectors.toList());
+  }
+}

--- a/src/main/java/org/folio/rest/impl/InvoiceHelper.java
+++ b/src/main/java/org/folio/rest/impl/InvoiceHelper.java
@@ -99,18 +99,11 @@ public class InvoiceHelper extends AbstractHelper {
     return handleDeleteRequest(String.format(DELETE_INVOICE_BY_ID, id, lang), httpClient, ctx, okapiHeaders, logger);
   }
 
-  public CompletableFuture<Void> updateInvoice(Invoice invoice) {
+  public CompletableFuture<Void> updateInvoice(Invoice invoice, Invoice invoiceFromStorage) {
     logger.debug("Updating invoice...");
 
-    return setSystemGeneratedData(invoice)
-      .thenCompose(updatedInvoice -> {
-        JsonObject jsonInvoice = JsonObject.mapFrom(updatedInvoice);
-        return handlePutRequest(resourceByIdPath(INVOICES, invoice.getId()), jsonInvoice, httpClient, ctx, okapiHeaders, logger);
-      });
-  }
-
-  private CompletableFuture<Invoice> setSystemGeneratedData(Invoice invoice) {
-    return getInvoice(invoice.getId())
-      .thenApply(invoiceFromStorage -> invoice.withFolioInvoiceNo(invoiceFromStorage.getFolioInvoiceNo()));
+    invoice.withFolioInvoiceNo(invoiceFromStorage.getFolioInvoiceNo());
+    JsonObject jsonInvoice = JsonObject.mapFrom(invoice);
+    return handlePutRequest(resourceByIdPath(INVOICES, invoice.getId()), jsonInvoice, httpClient, ctx, okapiHeaders, logger);
   }
 }

--- a/src/main/java/org/folio/rest/impl/InvoicesImpl.java
+++ b/src/main/java/org/folio/rest/impl/InvoicesImpl.java
@@ -1,13 +1,11 @@
 package org.folio.rest.impl;
 
-import static io.vertx.core.Future.succeededFuture;
-import static java.util.stream.Collectors.toSet;
-
-import java.util.*;
-import java.util.function.Consumer;
-
-import javax.ws.rs.core.Response;
-
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -19,12 +17,13 @@ import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Invoice;
 import org.folio.rest.jaxrs.model.InvoiceLine;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Handler;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import javax.ws.rs.core.Response;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static io.vertx.core.Future.succeededFuture;
+import static java.util.stream.Collectors.toSet;
 
 public class InvoicesImpl implements org.folio.rest.jaxrs.resource.Invoice {
 
@@ -97,7 +96,6 @@ public class InvoicesImpl implements org.folio.rest.jaxrs.resource.Invoice {
             try {
               return !EqualsBuilder.reflectionEquals(FieldUtils.readDeclaredField(invoice, field, true), FieldUtils.readDeclaredField(existed, field, true), true, Invoice.class, true);
             } catch (IllegalAccessException e) {
-              e.printStackTrace();
               asyncResultHandler.handle(succeededFuture(invoiceHelper.buildErrorResponse(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt())));
             }
             return false;
@@ -106,7 +104,7 @@ public class InvoicesImpl implements org.folio.rest.jaxrs.resource.Invoice {
             invoiceHelper.updateInvoice(invoice, existed)
               .thenAccept(success);
           } else {
-            invoiceHelper.addProcessingError(ErrorCodes.PROHIBITED_FIELD_CHANGING.toError().withAdditionalProperty("protectedAndModifiedFields", fields));
+            invoiceHelper.addProcessingError(ErrorCodes.PROHIBITED_FIELD_CHANGING.toError().withAdditionalProperty(PROTECTED_AND_MODIFIED_FIELDS, fields));
             asyncResultHandler.handle(succeededFuture(invoiceHelper.buildErrorResponse(HttpStatus.HTTP_BAD_REQUEST.toInt())));
           }
         } else {

--- a/src/main/java/org/folio/rest/impl/InvoicesImpl.java
+++ b/src/main/java/org/folio/rest/impl/InvoicesImpl.java
@@ -7,23 +7,25 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.folio.HttpStatus;
 import org.folio.invoices.utils.ErrorCodes;
-import org.folio.invoices.utils.InvoiceLineProtectedFields;
-import org.folio.invoices.utils.InvoiceProtectedFields;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Invoice;
 import org.folio.rest.jaxrs.model.InvoiceLine;
+import org.folio.rulez.Rules;
+import org.kie.api.event.rule.ObjectDeletedEvent;
+import org.kie.api.event.rule.ObjectInsertedEvent;
+import org.kie.api.event.rule.ObjectUpdatedEvent;
+import org.kie.api.event.rule.RuleRuntimeEventListener;
+import org.kie.api.runtime.KieSession;
 
 import javax.ws.rs.core.Response;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
 import static io.vertx.core.Future.succeededFuture;
-import static java.util.stream.Collectors.toSet;
 
 public class InvoicesImpl implements org.folio.rest.jaxrs.resource.Invoice {
 
@@ -31,7 +33,29 @@ public class InvoicesImpl implements org.folio.rest.jaxrs.resource.Invoice {
   private static final String NOT_SUPPORTED = "Not supported";  // To overcome sonarcloud warning
   private static final String INVOICE_LOCATION_PREFIX = "/invoice/invoices/%s";
   private static final String INVOICE_LINE_LOCATION_PREFIX = "/invoice/invoice-lines/%s";
-  public static final String PROTECTED_AND_MODIFIED_FIELDS = "protectedAndModifiedFields";
+  static final String PROTECTED_AND_MODIFIED_FIELDS = "protectedAndModifiedFields";
+  private static final String RULES_FILE_PATH = "src/main/resources/rules/not_autostarted";
+  private static final String $_PROTECTED_AND_MODIFIED_FIELDS = "$protectedAndModifiedFields";
+  private static final String $_EXISTED_INVOICE = "$existedInvoice";
+  private static final String $_EXISTED_INVOICE_LINE = "$existedInvoiceLine";
+
+  private KieSession session;
+
+  public InvoicesImpl() throws Exception {
+      session = new Rules(RULES_FILE_PATH).buildSession();
+      session.addEventListener(new RuleRuntimeEventListener() {
+        @Override
+        public void objectInserted(ObjectInsertedEvent event) {
+          session.fireAllRules();
+        }
+
+        @Override
+        public void objectUpdated(ObjectUpdatedEvent event) {}
+
+        @Override
+        public void objectDeleted(ObjectDeletedEvent event) {}
+      });
+  }
 
   @Validate
   @Override
@@ -92,19 +116,15 @@ public class InvoicesImpl implements org.folio.rest.jaxrs.resource.Invoice {
       .thenAccept(existed -> {
         final Consumer<Void> success = ok -> asyncResultHandler.handle(succeededFuture(invoiceHelper.buildNoContentResponse()));
         if(invoice.getStatus() == Invoice.Status.APPROVED || invoice.getStatus() == Invoice.Status.PAID || invoice.getStatus() == Invoice.Status.CANCELLED) {
-          Set<String> fields = InvoiceProtectedFields.getFieldNames().stream().filter(field -> {
-            try {
-              return !EqualsBuilder.reflectionEquals(FieldUtils.readDeclaredField(invoice, field, true), FieldUtils.readDeclaredField(existed, field, true), true, Invoice.class, true);
-            } catch (IllegalAccessException e) {
-              asyncResultHandler.handle(succeededFuture(invoiceHelper.buildErrorResponse(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt())));
-            }
-            return false;
-          }).collect(toSet());
-          if(fields.isEmpty()) {
+          Set<String> protectedAndModifiedFields = new HashSet<>();
+          session.setGlobal($_PROTECTED_AND_MODIFIED_FIELDS, protectedAndModifiedFields);
+          session.setGlobal($_EXISTED_INVOICE, existed);
+          session.insert(invoice);
+          if(protectedAndModifiedFields.isEmpty()) {
             invoiceHelper.updateInvoice(invoice, existed)
               .thenAccept(success);
           } else {
-            invoiceHelper.addProcessingError(ErrorCodes.PROHIBITED_FIELD_CHANGING.toError().withAdditionalProperty(PROTECTED_AND_MODIFIED_FIELDS, fields));
+            invoiceHelper.addProcessingError(ErrorCodes.PROHIBITED_FIELD_CHANGING.toError().withAdditionalProperty(PROTECTED_AND_MODIFIED_FIELDS, protectedAndModifiedFields));
             asyncResultHandler.handle(succeededFuture(invoiceHelper.buildErrorResponse(HttpStatus.HTTP_BAD_REQUEST.toInt())));
           }
         } else {
@@ -183,19 +203,15 @@ public class InvoicesImpl implements org.folio.rest.jaxrs.resource.Invoice {
         .thenAccept(existedInvoice -> {
           Consumer<Void> success = vVoid -> asyncResultHandler.handle(succeededFuture(invoiceLinesHelper.buildNoContentResponse()));
           if(existedInvoice.getStatus() == Invoice.Status.APPROVED || existedInvoice.getStatus() == Invoice.Status.PAID || existedInvoice.getStatus() == Invoice.Status.CANCELLED) {
-            Set<String> fields = InvoiceLineProtectedFields.getFieldNames().stream().filter(field -> {
-              try {
-                return !EqualsBuilder.reflectionEquals(FieldUtils.readDeclaredField(invoiceLine, field, true), FieldUtils.readDeclaredField(existedInvoiceLine, field, true), true, InvoiceLine.class, true);
-              } catch (IllegalAccessException e) {
-                asyncResultHandler.handle(succeededFuture(invoiceHelper.buildErrorResponse(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt())));
-              }
-              return false;
-            }).collect(toSet());
-            if(fields.isEmpty()) {
+            Set<String> protectedAndModifiedFields = new HashSet<>();
+            session.setGlobal($_PROTECTED_AND_MODIFIED_FIELDS, protectedAndModifiedFields);
+            session.setGlobal($_EXISTED_INVOICE_LINE, existedInvoiceLine);
+            session.insert(invoiceLine);
+            if(protectedAndModifiedFields.isEmpty()) {
               invoiceLinesHelper.updateInvoiceLine(invoiceLine)
                 .thenAccept(success);
             } else {
-              invoiceLinesHelper.addProcessingError(ErrorCodes.PROHIBITED_FIELD_CHANGING.toError().withAdditionalProperty(PROTECTED_AND_MODIFIED_FIELDS, fields));
+              invoiceLinesHelper.addProcessingError(ErrorCodes.PROHIBITED_FIELD_CHANGING.toError().withAdditionalProperty(PROTECTED_AND_MODIFIED_FIELDS, protectedAndModifiedFields));
               asyncResultHandler.handle(succeededFuture(invoiceLinesHelper.buildErrorResponse(HttpStatus.HTTP_BAD_REQUEST.toInt())));
             }
           } else {

--- a/src/main/resources/rules/not_autostarted/prevent_invoice_modification_rule.drl
+++ b/src/main/resources/rules/not_autostarted/prevent_invoice_modification_rule.drl
@@ -1,0 +1,29 @@
+import org.folio.rest.jaxrs.model.Invoice
+import org.folio.rest.jaxrs.model.InvoiceLine
+import org.apache.commons.lang3.reflect.FieldUtils
+import org.apache.commons.lang3.builder.EqualsBuilder
+import org.folio.invoices.utils.InvoiceProtectedFields
+import org.folio.invoices.utils.InvoiceLineProtectedFields
+
+global java.util.Set $protectedAndModifiedFields
+global org.folio.rest.jaxrs.model.Invoice $existedInvoice
+global org.folio.rest.jaxrs.model.InvoiceLine $existedInvoiceLine
+
+rule "Invoice: Filter of Attempts to Change of Prohibited For Modification Fields"
+  when
+    $updatedInvoice : Invoice();
+    $field : String() from InvoiceProtectedFields.getFieldNames();
+    eval(!EqualsBuilder.reflectionEquals(FieldUtils.readDeclaredField($updatedInvoice, $field, true), FieldUtils.readDeclaredField($existedInvoice, $field, true), true, Invoice.class, true));
+  then
+    $protectedAndModifiedFields.add($field);
+end
+
+rule "InvoiceLine: Filter of Attempts to Change of Prohibited For Modification Fields"
+  when
+    $updatedInvoiceLine : InvoiceLine();
+    $field : String() from InvoiceLineProtectedFields.getFieldNames();
+    eval(!EqualsBuilder.reflectionEquals(FieldUtils.readDeclaredField($updatedInvoiceLine, $field, true), FieldUtils.readDeclaredField($existedInvoiceLine, $field, true), true, InvoiceLine.class, true));
+  then
+    $protectedAndModifiedFields.add($field);
+end
+

--- a/src/test/java/org/folio/rest/impl/InvoiceLinesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoiceLinesApiTest.java
@@ -1,24 +1,16 @@
 package org.folio.rest.impl;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
-
-import com.google.common.collect.Lists;
 import io.restassured.http.Header;
 import io.restassured.response.Response;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-
-import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.http.HttpStatus;
 import org.folio.invoices.utils.InvoiceLineProtectedFields;
-import org.folio.invoices.utils.InvoiceProtectedFields;
 import org.folio.rest.jaxrs.model.Adjustment;
 import org.folio.rest.jaxrs.model.Errors;
-import org.folio.rest.jaxrs.model.Invoice;
 import org.folio.rest.jaxrs.model.InvoiceLine;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -26,20 +18,20 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.time.LocalDate;
 import java.util.*;
-import java.util.concurrent.ThreadLocalRandom;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.folio.invoices.utils.ResourcePathResolver.INVOICE_LINE_NUMBER;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
-import static org.folio.rest.impl.InvoicesApiTest.BAD_QUERY;
 import static org.folio.rest.impl.AbstractHelper.ID;
+import static org.folio.rest.impl.InvoicesApiTest.BAD_QUERY;
 import static org.folio.rest.impl.InvoicesImpl.PROTECTED_AND_MODIFIED_FIELDS;
+import static org.folio.rest.impl.MockServer.INVOICE_LINE_NUMBER_ERROR_X_OKAPI_TENANT;
 import static org.folio.rest.impl.MockServer.serverRqRs;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.folio.invoices.utils.ResourcePathResolver.INVOICE_LINE_NUMBER;
-import static org.folio.rest.impl.MockServer.INVOICE_LINE_NUMBER_ERROR_X_OKAPI_TENANT;
 
 
 public class InvoiceLinesApiTest extends ApiTestBase {

--- a/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
@@ -5,9 +5,6 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import java.io.IOException;
-import java.util.*;
-
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.http.HttpStatus;
 import org.folio.invoices.utils.InvoiceProtectedFields;
@@ -18,19 +15,19 @@ import org.folio.rest.jaxrs.model.InvoiceCollection;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.util.*;
+
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.folio.invoices.utils.ResourcePathResolver.FOLIO_INVOICE_NUMBER;
 import static org.folio.invoices.utils.ResourcePathResolver.INVOICES;
 import static org.folio.rest.impl.AbstractHelper.ID;
 import static org.folio.rest.impl.InvoicesImpl.PROTECTED_AND_MODIFIED_FIELDS;
-import static org.folio.rest.impl.MockServer.ERROR_X_OKAPI_TENANT;
-import static org.folio.rest.impl.MockServer.INVOICE_NUMBER_ERROR_X_OKAPI_TENANT;
-import static org.folio.rest.impl.MockServer.serverRqRs;
+import static org.folio.rest.impl.MockServer.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 public class InvoicesApiTest extends ApiTestBase {

--- a/src/test/resources/mockdata/invoiceLines/5cb6d270-a54c-4c38-b645-3ae7f249c606.json
+++ b/src/test/resources/mockdata/invoiceLines/5cb6d270-a54c-4c38-b645-3ae7f249c606.json
@@ -1,0 +1,37 @@
+{
+  "id": "5cb6d270-a54c-4c38-b645-3ae7f249c606",
+  "description": "Some description",
+  "invoiceLineNumber": "123invoicenumber45-1",
+  "invoiceLineStatus": "Open",
+  "vendorRefNo": "1",
+  "poLineId": "0610be6d-0ddd-494b-b867-19f63d8b5d6d",
+  "productId": "9780764354113",
+  "productIdType": "ISBN",
+  "comment": "Sample invoice line",
+  "subTotal": 2.2,
+  "quantity": 3,
+  "releaseEncumbrance": false,
+  "subscriptionInfo": "Subscription information",
+  "subscriptionStart": "2018-08-01T00:00:00.000+0000",
+  "subscriptionEnd": "2019-01-01T00:00:00.000+0000",
+  "invoiceId": "52fd6ec7-ddc3-4c53-bc26-2779afc27136",
+  "fundDistributions": [
+    {
+      "code": "EUHIST",
+      "encumbrance": "5f9bfc74-f6ff-4877-be1f-793f8ce90ade",
+      "fundId": "63157e96-0693-426d-b0df-948bacdfdb08",
+      "percentage": 50
+    }
+  ],
+  "adjustments": [
+    {
+      "adjustmentLabel": "Adjustment label",
+      "adjustmentType": "Percentage",
+      "adjustmentValue": 10.1
+    }
+  ],
+  "metadata": {
+    "createdDate": "2018-07-19T00:00:00.000+0000",
+    "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"
+  }
+}

--- a/src/test/resources/mockdata/invoiceLines/ebd42944-20fc-4448-86ad-60ec9b73a6d7.json
+++ b/src/test/resources/mockdata/invoiceLines/ebd42944-20fc-4448-86ad-60ec9b73a6d7.json
@@ -1,0 +1,37 @@
+{
+  "id": "5cb6d270-a54c-4c38-b645-3ae7f249c606",
+  "description": "Some description",
+  "invoiceLineNumber": "123invoicenumber45-1",
+  "invoiceLineStatus": "Open",
+  "vendorRefNo": "1",
+  "poLineId": "0610be6d-0ddd-494b-b867-19f63d8b5d6d",
+  "productId": "9780764354113",
+  "productIdType": "ISBN",
+  "comment": "Sample invoice line",
+  "subTotal": 2.2,
+  "quantity": 3,
+  "releaseEncumbrance": false,
+  "subscriptionInfo": "Subscription information",
+  "subscriptionStart": "2018-08-01T00:00:00.000+0000",
+  "subscriptionEnd": "2019-01-01T00:00:00.000+0000",
+  "invoiceId": "52fd6ec7-dec3-4c53-bc26-2779afc27136",
+  "fundDistributions": [
+    {
+      "code": "EUHIST",
+      "encumbrance": "5f9bfc74-f6ff-4877-be1f-793f8ce90ade",
+      "fundId": "63157e96-0693-426d-b0df-948bacdfdb08",
+      "percentage": 50
+    }
+  ],
+  "adjustments": [
+    {
+      "adjustmentLabel": "Adjustment label",
+      "adjustmentType": "Percentage",
+      "adjustmentValue": 10.1
+    }
+  ],
+  "metadata": {
+    "createdDate": "2018-07-19T00:00:00.000+0000",
+    "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"
+  }
+}

--- a/src/test/resources/mockdata/invoices/52fd6ec7-ddc3-4c53-bc26-2779afc27136.json
+++ b/src/test/resources/mockdata/invoices/52fd6ec7-ddc3-4c53-bc26-2779afc27136.json
@@ -1,5 +1,5 @@
 {
-  "id": "c0d08448-347b-418a-8c2f-5fb50248d67e",
+  "id": "52fd6ec7-ddc3-4c53-bc26-2779afc27136",
   "approvedBy": "ab18897b-0e40-4f31-896b-9c9adc979a88",
   "approvalDate": "2018-07-29T00:00:00.000+0000",
   "chkSubscriptionOverlap": false,
@@ -10,7 +10,7 @@
   "acquisitionsUnit": "d79b0bcc-DcAD-1E4E-Abb7-DbFcaD5BB3bb",
   "paymentTerms": "Payment in Advance",
   "paymentMethod": "EFT",
-  "status": "Approved",
+  "status": "Open",
   "source": "024b6f41-c5c6-4280-858e-33fba452a334",
   "total": 5.0,
   "vendorInvoiceNo": "YK75851",
@@ -18,13 +18,6 @@
   "paymentId": "a5065f0d-fb88-4d23-b0c1-57e754fba40e",
   "poNumbers": [
     "AB268758XYZ"
-  ],
-  "adjustments": [
-    {
-      "adjustmentLabel": "Adjustment label",
-      "adjustmentType": "Percentage",
-      "adjustmentValue": 10.1
-    }
   ],
   "vendorId": "168f8a63-d612-406e-813f-c7527f241ac3",
   "manualPayment": true


### PR DESCRIPTION
[MODINVOICE-35](https://issues.folio.org/browse/MODINVOICE-35) - Prevent modifications to invoice/invoice lines once status is "Approved"

## Purpose
When an invoice transitions to "Approved" many of the fields in the invoice and associated invoice lines should not be allowed to be updated.

## Approach
Drools-based approach - updating PUT invoice and invoice line endpoints to prevent objects modification.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.