### PR TITLE
MODINVOSTO-22/MODINVOICE-60 Schema updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <jsonschema_paths>acq-models/mod-invoice-storage/schemas,raml-util/schemas,acq-models/common/schemas/</jsonschema_paths>
-    <raml-module-builder.version>24.0.0</raml-module-builder.version>
+    <raml-module-builder.version>25.0.1</raml-module-builder.version>
     <vertx.version>3.5.4</vertx.version>
     <junit.version>4.12</junit.version>
     <rest-assured.version>3.1.1</rest-assured.version>

--- a/src/main/java/org/folio/invoices/utils/InvoiceLineProtectedFields.java
+++ b/src/main/java/org/folio/invoices/utils/InvoiceLineProtectedFields.java
@@ -15,8 +15,7 @@ public enum InvoiceLineProtectedFields {
   QUANTITY("quantity"),
   SUBSCRIPTION_INFO("subscriptionInfo"),
   SUBSCRIPTION_START("subscriptionStart"),
-  SUBSCRIPTION_END("subscriptionEnd"),
-  TOTAL("total");
+  SUBSCRIPTION_END("subscriptionEnd");
 
 
   InvoiceLineProtectedFields(String field) {

--- a/src/test/java/org/folio/rest/impl/InvoiceLinesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoiceLinesApiTest.java
@@ -449,7 +449,6 @@ public class InvoiceLinesApiTest extends ApiTestBase {
     allProtectedFieldsModification.put(InvoiceLineProtectedFields.SUBSCRIPTION_INFO, "Tested subscription info");
     allProtectedFieldsModification.put(InvoiceLineProtectedFields.SUBSCRIPTION_START, new Date(System.currentTimeMillis()));
     allProtectedFieldsModification.put(InvoiceLineProtectedFields.SUBSCRIPTION_END, new Date(System.currentTimeMillis()));
-    allProtectedFieldsModification.put(InvoiceLineProtectedFields.TOTAL, 123.123);
 
     checkPreventInvoiceLineModificationRule(allProtectedFieldsModifiedInvoiceLine, allProtectedFieldsModification);
 

--- a/src/test/resources/mockdata/invoices/3ff985f9-27dc-40c9-b495-1f54d2af6700.json
+++ b/src/test/resources/mockdata/invoices/3ff985f9-27dc-40c9-b495-1f54d2af6700.json
@@ -7,7 +7,6 @@
   "folioInvoiceNo": "invoicenumber45",
   "invoiceDate": "2018-07-20T00:00:00.000+0000",
   "note": "Some note 1",
-  "acquisitionsUnit": "d79b0bcc-DcAD-1E4E-Abb7-DbFcaD5BB3bb",
   "paymentTerms": "Payment in Advance",
   "paymentMethod": "EFT",
   "status": "Approved",

--- a/src/test/resources/mockdata/invoices/52fd6ec7-ddc3-4c53-bc26-2779afc27136.json
+++ b/src/test/resources/mockdata/invoices/52fd6ec7-ddc3-4c53-bc26-2779afc27136.json
@@ -7,7 +7,6 @@
   "folioInvoiceNo": "123invoicenumber45",
   "invoiceDate": "2018-07-20T00:00:00.000+0000",
   "note": "Some note 1",
-  "acquisitionsUnit": "d79b0bcc-DcAD-1E4E-Abb7-DbFcaD5BB3bb",
   "paymentTerms": "Payment in Advance",
   "paymentMethod": "EFT",
   "status": "Open",

--- a/src/test/resources/mockdata/invoices/c0d08448-347b-418a-8c2f-5fb50248d67e.json
+++ b/src/test/resources/mockdata/invoices/c0d08448-347b-418a-8c2f-5fb50248d67e.json
@@ -7,7 +7,6 @@
   "folioInvoiceNo": "123invoicenumber45",
   "invoiceDate": "2018-07-20T00:00:00.000+0000",
   "note": "Some note 1",
-  "acquisitionsUnit": "d79b0bcc-DcAD-1E4E-Abb7-DbFcaD5BB3bb",
   "paymentTerms": "Payment in Advance",
   "paymentMethod": "EFT",
   "status": "Approved",


### PR DESCRIPTION
## Purpose
[MODINVOSTO-22](https://issues.folio.org/browse/MODINVOSTO-22) Remove invoice.acquisitionsUnit
[MODINVOICE-60](https://issues.folio.org/browse/MODINVOICE-60) Invoice schemas - readonly properties

## Approach
- pointing to updated acq-models sub-module
- RMB version is `25.0.1`
- updating mock data and validation

#### TODOS and Open Questions
- [x] Point to merge commit once https://github.com/folio-org/acq-models/pull/150 is merged
- [ ] Merge together with https://github.com/folio-org/mod-invoice-storage/pull/23

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [x] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
