### PR TITLE
MODINVOICE-36 Mark voucher as paid on transition to invoice status "Paid"

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -43,7 +43,9 @@
             "invoice-storage.invoices.item.get",
             "invoice-storage.invoice-lines.collection.get",
             "orders.po-lines.item.put",
-            "orders.po-lines.item.get"
+            "orders.po-lines.item.get",
+            "voucher-storage.vouchers.collection.get",
+            "voucher-storage.vouchers.item.put"
           ]
         },
         {

--- a/src/main/java/org/folio/invoices/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/invoices/utils/ErrorCodes.java
@@ -6,6 +6,9 @@ public enum ErrorCodes {
 
   GENERIC_ERROR_CODE("genericError", "Generic error"),
   PO_LINE_NOT_FOUND("poLineNotFound", "The purchase order line record is not found"),
+  PO_LINE_UPDATE_FAILURE("poLineUpdateFailure", "One or more purchase order line record(s) cannot be updated"),
+  VOUCHER_NOT_FOUND("voucherNotFound", "The voucher record is not found"),
+  VOUCHER_UPDATE_FAILURE("voucherUpdateFailure", "Voucher record cannot be updated"),
   INVOICE_TOTAL_REQUIRED("invoiceTotalRequired", "The total amount is expected when lockTotal is true"),
   PROHIBITED_FIELD_CHANGING("protectedFieldChanging", "Field can't be modified");
 

--- a/src/main/java/org/folio/invoices/utils/HelperUtils.java
+++ b/src/main/java/org/folio/invoices/utils/HelperUtils.java
@@ -39,18 +39,13 @@ public class HelperUtils {
   private static final String EXCEPTION_CALLING_ENDPOINT_MSG = "Exception calling {} {}";
   private static final String CALLING_ENDPOINT_MSG = "Sending {} {}";
 
-  public static final String URL_WITH_LANG_PARAM = "%s?lang=%s";
-  private static final String GET_INVOICE_BYID = resourceByIdPath(INVOICES) + URL_WITH_LANG_PARAM;
-  private static final String GET_VOUCHER_LINES_BYID = resourceByIdPath(VOUCHER_LINES) + URL_WITH_LANG_PARAM;
-  private static final String GET_VOUCHER_BY_ID = resourceByIdPath(VOUCHERS) + URL_WITH_LANG_PARAM;
-
   private HelperUtils() {
 
   }
 
   public static CompletableFuture<Invoice> getInvoiceById(String id, String lang, HttpClientInterface httpClient, Context ctx,
       Map<String, String> okapiHeaders, Logger logger) {
-    String endpoint = String.format(GET_INVOICE_BYID, id, lang);
+    String endpoint = resourceByIdPath(INVOICES, id, lang);
     return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
       .thenApply(jsonInvoice -> {
         if (logger.isInfoEnabled()) {
@@ -62,13 +57,13 @@ public class HelperUtils {
 
   public static CompletableFuture<JsonObject> getVoucherLineById(String id, String lang, HttpClientInterface httpClient,
                                                                  Context ctx, Map<String, String> okapiHeaders, Logger logger) {
-    String endpoint = String.format(GET_VOUCHER_LINES_BYID, id, lang);
+    String endpoint = resourceByIdPath(VOUCHER_LINES, id, lang);
     return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger);
   }
 
   public static CompletableFuture<JsonObject> getVoucherById(String id, String lang, HttpClientInterface httpClient, Context ctx,
       Map<String, String> okapiHeaders, Logger logger) {
-    String endpoint = String.format(GET_VOUCHER_BY_ID, id, lang);
+    String endpoint = resourceByIdPath(VOUCHERS, id, lang);
     return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger);
   }
 

--- a/src/main/java/org/folio/invoices/utils/ResourcePathResolver.java
+++ b/src/main/java/org/folio/invoices/utils/ResourcePathResolver.java
@@ -12,6 +12,7 @@ public class ResourcePathResolver {
 
   public static final String INVOICES = "invoices";
   public static final String INVOICE_LINES = "invoiceLines";
+  public static final String ORDER_LINES = "orderLines";
   public static final String VOUCHER_LINES = "voucherLines";
   public static final String VOUCHER_NUMBER_START = "voucherNumberStart";
   public static final String FOLIO_INVOICE_NUMBER = "folioInvoiceNo";
@@ -26,6 +27,7 @@ public class ResourcePathResolver {
     apis.put(INVOICES, "/invoice-storage/invoices");
     apis.put(INVOICE_LINES, "/invoice-storage/invoice-lines");
     apis.put(INVOICE_LINE_NUMBER, "/invoice-storage/invoice-line-number");
+    apis.put(ORDER_LINES, "/orders/order-lines");
     apis.put(FOLIO_INVOICE_NUMBER, "/invoice-storage/invoice-number");
     apis.put(VOUCHERS, "/voucher-storage/vouchers");
     apis.put(VOUCHER_LINES, "/voucher-storage/voucher-lines");
@@ -35,16 +37,12 @@ public class ResourcePathResolver {
     SUB_OBJECT_ITEM_APIS = Collections.unmodifiableMap(
         apis.entrySet()
             .stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, v -> v.getValue() + "/"))
+            .collect(Collectors.toMap(Map.Entry::getKey, v -> v.getValue() + "/%s?lang=%s"))
       );
   }
 
-  public static String resourceByIdPath(String field) {
-    return SUB_OBJECT_ITEM_APIS.get(field);
-  }
-
-  public static String resourceByIdPath(String field, String id) {
-    return SUB_OBJECT_ITEM_APIS.get(field) + id;
+  public static String resourceByIdPath(String field, String id, String lang) {
+    return String.format(SUB_OBJECT_ITEM_APIS.get(field), id, lang);
   }
 
   public static String resourcesPath(String field) {

--- a/src/main/java/org/folio/rest/impl/InvoiceLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/InvoiceLineHelper.java
@@ -34,9 +34,6 @@ public class InvoiceLineHelper extends AbstractHelper {
   private static final String INVOICE_ID = "invoiceId";
   private static final String INVOICE_LINE_NUMBER_ENDPOINT = resourcesPath(INVOICE_LINE_NUMBER) + "?" + INVOICE_ID + "=";
   private static final String GET_INVOICE_LINES_BY_QUERY = resourcesPath(INVOICE_LINES) + "?limit=%s&offset=%s%s&lang=%s";
-  private static final String INVOICE_LINE_BYID_ENDPOINT = resourceByIdPath(INVOICE_LINES, "%s") + "?lang=%s";
-
-
 
   InvoiceLineHelper(Map<String, String> okapiHeaders, Context ctx, String lang) {
     super(getHttpClient(okapiHeaders), okapiHeaders, ctx, lang);
@@ -75,7 +72,7 @@ public class InvoiceLineHelper extends AbstractHelper {
     CompletableFuture<InvoiceLine> future = new VertxCompletableFuture<>(ctx);
 
     try {
-      handleGetRequest(String.format(INVOICE_LINE_BYID_ENDPOINT, id, lang), httpClient, ctx, okapiHeaders, logger)
+      handleGetRequest(resourceByIdPath(INVOICE_LINES, id, lang), httpClient, ctx, okapiHeaders, logger)
         .thenAccept(jsonInvoiceLine -> {
           logger.info("Successfully retrieved invoice line: " + jsonInvoiceLine.encodePrettily());
           future.complete(jsonInvoiceLine.mapTo(InvoiceLine.class));
@@ -101,8 +98,8 @@ public class InvoiceLineHelper extends AbstractHelper {
           invoiceLine.setInvoiceLineNumber(existedInvoiceLine.getInvoiceLineNumber());
         })
       )
-      .thenCompose(aVoid -> handlePutRequest(resourceByIdPath(INVOICE_LINES, invoiceLine.getId()), JsonObject.mapFrom(invoiceLine),
-        httpClient, ctx, okapiHeaders, logger));
+      .thenCompose(ok -> handlePutRequest(resourceByIdPath(INVOICE_LINES, invoiceLine.getId(), lang),
+          JsonObject.mapFrom(invoiceLine), httpClient, ctx, okapiHeaders, logger));
   }
 
   private void validateInvoiceLine(Invoice existedInvoice, InvoiceLine invoiceLine, InvoiceLine existedInvoiceLine) {
@@ -185,6 +182,6 @@ public class InvoiceLineHelper extends AbstractHelper {
   }
 
   public CompletableFuture<Void> deleteInvoiceLine(String id) {
-    return handleDeleteRequest(String.format(INVOICE_LINE_BYID_ENDPOINT, id, lang), httpClient, ctx, okapiHeaders, logger);
+    return handleDeleteRequest(resourceByIdPath(INVOICE_LINES, id, lang), httpClient, ctx, okapiHeaders, logger);
   }
 }

--- a/src/main/java/org/folio/rest/impl/VoucherLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/VoucherLineHelper.java
@@ -21,8 +21,8 @@ public class VoucherLineHelper extends AbstractHelper {
   }
 
   public CompletableFuture<Void> updateVoucherLine(VoucherLine voucherLine) {
-    return handlePutRequest(resourceByIdPath(VOUCHER_LINES, voucherLine.getId()), JsonObject.mapFrom(voucherLine), httpClient, ctx,
-        okapiHeaders, logger);
+    String path = resourceByIdPath(VOUCHER_LINES, voucherLine.getId(), lang);
+    return handlePutRequest(path, JsonObject.mapFrom(voucherLine), httpClient, ctx, okapiHeaders, logger);
   }
 
   public CompletableFuture<VoucherLine> getVoucherLines(String id) {

--- a/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
@@ -7,7 +7,6 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -24,6 +23,8 @@ import org.folio.rest.jaxrs.model.Invoice;
 import org.folio.rest.jaxrs.model.InvoiceCollection;
 import org.folio.rest.jaxrs.model.InvoiceLine;
 import org.folio.rest.jaxrs.model.InvoiceLineCollection;
+import org.folio.rest.jaxrs.model.Voucher;
+import org.folio.rest.jaxrs.model.VoucherCollection;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -34,10 +35,14 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.folio.invoices.utils.ErrorCodes.INVOICE_TOTAL_REQUIRED;
 import static org.folio.invoices.utils.ErrorCodes.PO_LINE_NOT_FOUND;
+import static org.folio.invoices.utils.ErrorCodes.PO_LINE_UPDATE_FAILURE;
 import static org.folio.invoices.utils.ErrorCodes.PROHIBITED_FIELD_CHANGING;
+import static org.folio.invoices.utils.ErrorCodes.VOUCHER_NOT_FOUND;
+import static org.folio.invoices.utils.ErrorCodes.VOUCHER_UPDATE_FAILURE;
 import static org.folio.invoices.utils.ResourcePathResolver.FOLIO_INVOICE_NUMBER;
 import static org.folio.invoices.utils.ResourcePathResolver.INVOICES;
 import static org.folio.invoices.utils.ResourcePathResolver.INVOICE_LINES;
+import static org.folio.invoices.utils.ResourcePathResolver.VOUCHERS;
 import static org.folio.rest.impl.InvoicesImpl.PROTECTED_AND_MODIFIED_FIELDS;
 import static org.folio.rest.impl.InvoiceLinesApiTest.INVOICE_LINE_SAMPLE_PATH;
 import static org.folio.rest.impl.MockServer.ERROR_X_OKAPI_TENANT;
@@ -46,8 +51,10 @@ import static org.folio.rest.impl.MockServer.PO_LINES;
 import static org.folio.rest.impl.MockServer.addMockEntry;
 import static org.folio.rest.impl.MockServer.getRqRsEntries;
 import static org.folio.rest.impl.MockServer.serverRqRs;
+import static org.folio.rest.impl.VouchersApiTest.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -238,13 +245,16 @@ public class InvoicesApiTest extends ApiTestBase {
   public void testUpdateValidInvoiceTransitionToPaidWithMissingPoLine() {
     logger.info("=== Test transition invoice to paid with deleted associated poLine ===");
 
-    Invoice reqData = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class);
-    InvoiceLine invoiceLine = getMockAsJson(INVOICE_LINE_SAMPLE_PATH).mapTo(InvoiceLine.class);
-    reqData.setStatus(Invoice.Status.PAID);
+    Invoice reqData = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class).withStatus(Invoice.Status.PAID);
     String id = reqData.getId();
+
+    InvoiceLine invoiceLine = getMockAsJson(INVOICE_LINE_SAMPLE_PATH).mapTo(InvoiceLine.class);
     invoiceLine.setInvoiceId(id);
     invoiceLine.setPoLineId(ID_DOES_NOT_EXIST);
-    serverRqRs.put(INVOICE_LINES, HttpMethod.POST, Collections.singletonList(JsonObject.mapFrom(invoiceLine)));
+
+    addMockEntry(INVOICE_LINES, JsonObject.mapFrom(invoiceLine));
+    prepareMockVoucher(id);
+
     String jsonBody = JsonObject.mapFrom(reqData).encode();
 
     Errors errors = verifyPut(String.format(INVOICE_ID_PATH, id), jsonBody, APPLICATION_JSON, 500).then().extract().body().as(Errors.class);
@@ -258,16 +268,22 @@ public class InvoicesApiTest extends ApiTestBase {
   public void testUpdateValidInvoiceTransitionToPaidWitErrorOnPoLineUpdate() {
     logger.info("=== Test transition invoice to paid with server error poLine update ===");
 
-    Invoice reqData = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class);
-    InvoiceLine invoiceLine = getMockAsJson(INVOICE_LINE_SAMPLE_PATH).mapTo(InvoiceLine.class);
-    reqData.setStatus(Invoice.Status.PAID);
+    Invoice reqData = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class).withStatus(Invoice.Status.PAID);
     String id = reqData.getId();
+
+    InvoiceLine invoiceLine = getMockAsJson(INVOICE_LINE_SAMPLE_PATH).mapTo(InvoiceLine.class);
     invoiceLine.setInvoiceId(id);
     invoiceLine.setPoLineId(ID_FOR_INTERNAL_SERVER_ERROR_PUT);
-    serverRqRs.put(INVOICE_LINES, HttpMethod.POST, Collections.singletonList(JsonObject.mapFrom(invoiceLine)));
+
+    addMockEntry(INVOICE_LINES, JsonObject.mapFrom(invoiceLine));
+    prepareMockVoucher(id);
+
     String jsonBody = JsonObject.mapFrom(reqData).encode();
 
-    verifyPut(String.format(INVOICE_ID_PATH, id), jsonBody, APPLICATION_JSON, 500);
+    Errors errors = verifyPut(String.format(INVOICE_ID_PATH, id), jsonBody, APPLICATION_JSON, 500).as(Errors.class);
+    assertThat(serverRqRs.get(INVOICES, HttpMethod.PUT), nullValue());
+    assertThat(errors.getErrors(), hasSize(1));
+    assertThat(errors.getErrors().get(0).getCode(), equalTo(PO_LINE_UPDATE_FAILURE.getCode()));
     assertThat(serverRqRs.get(INVOICES, HttpMethod.PUT), nullValue());
   }
 
@@ -275,22 +291,89 @@ public class InvoicesApiTest extends ApiTestBase {
   public void testUpdateValidInvoiceTransitionToPaid() {
     logger.info("=== Test transition invoice to paid and mixed releaseEncumbrance ===");
 
-    Invoice reqData = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class);
-    reqData.setStatus(Invoice.Status.PAID);
-
+    Invoice reqData = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class).withStatus(Invoice.Status.PAID);
     String id = reqData.getId();
+
+    prepareMockVoucher(id);
+
     String jsonBody = JsonObject.mapFrom(reqData).encode();
 
     verifyPut(String.format(INVOICE_ID_PATH, id), jsonBody, "", 204);
     assertThat(serverRqRs.get(INVOICES, HttpMethod.PUT).get(0).getString(STATUS), is(Invoice.Status.PAID.value()));
+
     validatePoLinesPaymentStatus();
+    assertThatVoucherPaid();
+  }
+
+  @Test
+  public void testUpdateInvoiceTransitionToPaidNoVoucherUpdate() {
+    logger.info("=== Test transition invoice to paid - voucher already paid ===");
+
+    Invoice reqData = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class).withStatus(Invoice.Status.PAID);
+    String id = reqData.getId();
+
+    // Prepare already paid voucher
+    Voucher voucher = getMockAsJson(VOUCHERS_LIST_PATH).mapTo(VoucherCollection.class).getVouchers().get(0);
+    voucher.setInvoiceId(id);
+    voucher.setStatus(Voucher.Status.PAID);
+    addMockEntry(VOUCHERS, JsonObject.mapFrom(voucher));
+
+    String jsonBody = JsonObject.mapFrom(reqData).encode();
+
+    verifyPut(String.format(INVOICE_ID_PATH, id), jsonBody, "", 204);
+
+    assertThat(getRqRsEntries(HttpMethod.GET, VOUCHERS), hasSize(1));
+    assertThat(getRqRsEntries(HttpMethod.PUT, VOUCHERS), empty());
+    assertThat(getRqRsEntries(HttpMethod.PUT, INVOICES), hasSize(1));
+    assertThat(getRqRsEntries(HttpMethod.PUT, INVOICES).get(0).getString(STATUS), is(Invoice.Status.PAID.value()));
+  }
+
+  @Test
+  public void testUpdateInvoiceTransitionToPaidNoVoucher() {
+    logger.info("=== Test transition invoice to paid - no voucher found ===");
+
+    Invoice reqData = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class).withStatus(Invoice.Status.PAID);
+    //prepareMockVoucher(reqData.getId());
+
+    String url = String.format(INVOICE_ID_PATH, reqData.getId());
+    Errors errors = verifyPut(url, JsonObject.mapFrom(reqData), APPLICATION_JSON, 500).as(Errors.class);
+
+    assertThat(errors.getErrors(), hasSize(1));
+    assertThat(errors.getErrors().get(0).getCode(), equalTo(VOUCHER_NOT_FOUND.getCode()));
+    assertThat(getRqRsEntries(HttpMethod.GET, INVOICES), hasSize(1));
+    assertThat(getRqRsEntries(HttpMethod.PUT, INVOICES), empty());
+    assertThat(getRqRsEntries(HttpMethod.PUT, VOUCHERS), empty());
+  }
+
+  @Test
+  public void testUpdateInvoiceTransitionToPaidVoucherUpdateFailure() {
+    logger.info("=== Test transition invoice to paid - voucher update failure ===");
+
+    Invoice reqData = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class).withStatus(Invoice.Status.PAID);
+    prepareMockVoucher(reqData.getId(), true);
+
+    String url = String.format(INVOICE_ID_PATH, reqData.getId());
+    Errors errors = verifyPut(url, JsonObject.mapFrom(reqData), APPLICATION_JSON, 500).as(Errors.class);
+
+    assertThat(errors.getErrors(), hasSize(1));
+    assertThat(errors.getErrors().get(0).getCode(), equalTo(VOUCHER_UPDATE_FAILURE.getCode()));
+    assertThat(getRqRsEntries(HttpMethod.PUT, INVOICES), empty());
   }
 
   private void validatePoLinesPaymentStatus() {
-    List<JsonObject> poLineUpdates = serverRqRs.get(PO_LINES, HttpMethod.PUT);
-    assertThat(poLineUpdates, notNullValue());
-    final List<CompositePoLine> updatedPoLines = poLineUpdates.stream().map(poLine -> poLine.mapTo(CompositePoLine.class)).collect(Collectors.toList());
-    Map<String, List<InvoiceLine>> invoiceLines = serverRqRs.get(INVOICE_LINES, HttpMethod.GET).get(0).mapTo(InvoiceLineCollection.class).getInvoiceLines().stream().collect(groupingBy(InvoiceLine::getPoLineId));
+
+    final List<CompositePoLine> updatedPoLines = getRqRsEntries(HttpMethod.PUT, PO_LINES).stream()
+      .map(poLine -> poLine.mapTo(CompositePoLine.class))
+      .collect(Collectors.toList());
+
+    assertThat(updatedPoLines, not(empty()));
+
+    Map<String, List<InvoiceLine>> invoiceLines = getRqRsEntries(HttpMethod.GET, INVOICE_LINES).get(0)
+      .mapTo(InvoiceLineCollection.class)
+      .getInvoiceLines()
+      .stream()
+      .collect(groupingBy(InvoiceLine::getPoLineId));
+
     assertThat(invoiceLines.size(), equalTo(updatedPoLines.size()));
 
     for (Map.Entry<String, List<InvoiceLine>> poLineIdWithInvoiceLines : invoiceLines.entrySet()) {
@@ -304,33 +387,31 @@ public class InvoicesApiTest extends ApiTestBase {
     }
   }
 
+  private void assertThatVoucherPaid() {
+    assertThat(getRqRsEntries(HttpMethod.PUT, VOUCHERS), hasSize(1));
+    assertThat(getRqRsEntries(HttpMethod.PUT, VOUCHERS).get(0).mapTo(Voucher.class).getStatus(), is(Voucher.Status.PAID));
+  }
+
   @Test
   public void testUpdateValidInvoiceTransitionToPaidReleaseEncumbranceFalse() {
     logger.info("=== Test transition invoice to paid and releaseEncumbrance false for all invoice lines ===");
-    List<InvoiceLine> invoiceLines = new ArrayList<>();
+
+    Invoice reqData = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class).withStatus(Invoice.Status.PAID);
+    String id = reqData.getId();
+
+    // Prepare invoice lines
     for (int i = 0; i < 3; i++) {
-      invoiceLines.add(getMockAsJson(INVOICE_LINE_SAMPLE_PATH).mapTo(InvoiceLine.class));
+      InvoiceLine invoiceLine = getMockAsJson(INVOICE_LINE_SAMPLE_PATH).mapTo(InvoiceLine.class);
+      invoiceLine.setId(UUID.randomUUID().toString());
+      invoiceLine.setInvoiceId(id);
+      invoiceLine.setPoLineId(EXISTENT_PO_LINE_ID);
+      invoiceLine.setReleaseEncumbrance(false);
+      addMockEntry(INVOICE_LINES, JsonObject.mapFrom(invoiceLine));
     }
 
-    Invoice reqData = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class);
-    List<JsonObject> preparedInvoiceLines = invoiceLines.stream()
-      .peek(invoiceLine -> {
-        invoiceLine.setId(UUID.randomUUID().toString());
-        invoiceLine.setInvoiceId(reqData.getId());
-        invoiceLine.setPoLineId(EXISTENT_PO_LINE_ID);
-        invoiceLine.setReleaseEncumbrance(false);
-      })
-      .map(JsonObject::mapFrom)
-      .collect(Collectors.toList());
+    prepareMockVoucher(id);
 
-    serverRqRs.put(INVOICE_LINES, HttpMethod.POST, preparedInvoiceLines);
-
-    reqData.setStatus(Invoice.Status.PAID);
-
-    String id = reqData.getId();
-    String jsonBody = JsonObject.mapFrom(reqData).encode();
-
-    verifyPut(String.format(INVOICE_ID_PATH, id), jsonBody, "", 204);
+    verifyPut(String.format(INVOICE_ID_PATH, id), JsonObject.mapFrom(reqData), "", 204);
 
     assertThat(serverRqRs.get(INVOICES, HttpMethod.PUT).get(0).getString(STATUS), is(Invoice.Status.PAID.value()));
     assertThat(serverRqRs.get(INVOICE_LINES, HttpMethod.GET), notNullValue());
@@ -343,46 +424,44 @@ public class InvoicesApiTest extends ApiTestBase {
   @Test
   public void testUpdateValidInvoiceTransitionToPaidReleaseEncumbranceFalseNoPoLineUpdate() {
     logger.info("=== Test transition invoice to paid and releaseEncumbrance false for invoice line without poLine update ===");
-    List<InvoiceLine> invoiceLines = new ArrayList<>();
-    List<CompositePoLine> poLines = new ArrayList<>();
+
+    Invoice reqData = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class).withStatus(Invoice.Status.PAID);
+    String id = reqData.getId();
 
     InvoiceLine invoiceLine = getMockAsJson(INVOICE_LINE_SAMPLE_PATH).mapTo(InvoiceLine.class);
-    invoiceLines.add(invoiceLine);
-    CompositePoLine poLine = getMockAsJson(String.format("%s%s.json", PO_LINE_MOCK_DATA_PATH, EXISTENT_PO_LINE_ID)).mapTo(CompositePoLine.class);
-    poLines.add(poLine);
-
-    Invoice reqData = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class);
-
     invoiceLine.setId(UUID.randomUUID().toString());
-    invoiceLine.setInvoiceId(reqData.getId());
+    invoiceLine.setInvoiceId(id);
     invoiceLine.setPoLineId(EXISTENT_PO_LINE_ID);
     invoiceLine.setReleaseEncumbrance(false);
 
+    CompositePoLine poLine = getMockAsJson(String.format("%s%s.json", PO_LINE_MOCK_DATA_PATH, EXISTENT_PO_LINE_ID)).mapTo(CompositePoLine.class);
     poLine.setId(EXISTENT_PO_LINE_ID);
     poLine.setPaymentStatus(CompositePoLine.PaymentStatus.PARTIALLY_PAID);
 
-    List<JsonObject> preparedInvoiceLines = invoiceLines.stream()
-      .map(JsonObject::mapFrom)
-      .collect(Collectors.toList());
+    addMockEntry(INVOICE_LINES, JsonObject.mapFrom(invoiceLine));
+    addMockEntry(PO_LINES, JsonObject.mapFrom(poLine));
+    prepareMockVoucher(id);
 
-    List<JsonObject> preparedPoLines = poLines.stream()
-      .map(JsonObject::mapFrom)
-      .collect(Collectors.toList());
+    verifyPut(String.format(INVOICE_ID_PATH, id), JsonObject.mapFrom(reqData), "", 204);
 
-    serverRqRs.put(INVOICE_LINES, HttpMethod.POST, preparedInvoiceLines);
-    serverRqRs.put(PO_LINES, HttpMethod.POST, preparedPoLines);
+    assertThat(getRqRsEntries(HttpMethod.PUT, INVOICES).get(0).getString(STATUS), is(Invoice.Status.PAID.value()));
+    assertThat(getRqRsEntries(HttpMethod.GET, INVOICE_LINES), hasSize(1));
+    assertThat(getRqRsEntries(HttpMethod.GET, INVOICE_LINES).get(0).mapTo(InvoiceLineCollection.class).getTotalRecords(), equalTo(1));
+    assertThat(getRqRsEntries(HttpMethod.PUT, PO_LINES), empty());
+    assertThatVoucherPaid();
+  }
 
-    reqData.setStatus(Invoice.Status.PAID);
+  private void prepareMockVoucher(String invoiceId) {
+    prepareMockVoucher(invoiceId, false);
+  }
 
-    String id = reqData.getId();
-    String jsonBody = JsonObject.mapFrom(reqData).encode();
-
-    verifyPut(String.format(INVOICE_ID_PATH, id), jsonBody, "", 204);
-
-    assertThat(serverRqRs.get(INVOICES, HttpMethod.PUT).get(0).getString(STATUS), is(Invoice.Status.PAID.value()));
-    assertThat(serverRqRs.get(INVOICE_LINES, HttpMethod.GET), notNullValue());
-    assertThat(serverRqRs.get(INVOICE_LINES, HttpMethod.GET).get(0).mapTo(InvoiceLineCollection.class).getTotalRecords(), equalTo(1));
-    assertThat(serverRqRs.get(PO_LINES, HttpMethod.PUT), nullValue());
+  private void prepareMockVoucher(String invoiceId, boolean failOnUpdate) {
+    Voucher voucher = getMockAsJson(VOUCHERS_LIST_PATH).mapTo(VoucherCollection.class).getVouchers().get(0);
+    voucher.setInvoiceId(invoiceId);
+    if (failOnUpdate) {
+      voucher.setId(ID_FOR_INTERNAL_SERVER_ERROR_PUT);
+    }
+    addMockEntry(VOUCHERS, JsonObject.mapFrom(voucher));
   }
 
   @Test
@@ -395,7 +474,8 @@ public class InvoicesApiTest extends ApiTestBase {
       poLines.add(getMockAsJson(String.format("%s%s.json", PO_LINE_MOCK_DATA_PATH, EXISTENT_PO_LINE_ID)).mapTo(CompositePoLine.class));
     }
 
-    Invoice reqData = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class);
+    Invoice reqData = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class).withStatus(Invoice.Status.PAID);
+    String id = reqData.getId();
     for (int i = 0; i < 3; i++) {
       invoiceLines.get(i).setId(UUID.randomUUID().toString());
       invoiceLines.get(i).setInvoiceId(reqData.getId());
@@ -404,31 +484,20 @@ public class InvoicesApiTest extends ApiTestBase {
       poLines.get(i).setId(poLineId);
     }
 
-    List<JsonObject> preparedInvoiceLines = invoiceLines.stream()
-      .map(JsonObject::mapFrom)
-      .collect(Collectors.toList());
-    List<JsonObject> preparedPoLines = poLines.stream()
-      .map(JsonObject::mapFrom)
-      .collect(Collectors.toList());
+    invoiceLines.forEach(line -> addMockEntry(INVOICE_LINES, JsonObject.mapFrom(line)));
+    poLines.forEach(line -> addMockEntry(PO_LINES, JsonObject.mapFrom(line)));
+    prepareMockVoucher(id);
 
-    serverRqRs.put(INVOICE_LINES, HttpMethod.POST, preparedInvoiceLines);
-    serverRqRs.put(PO_LINES, HttpMethod.POST, preparedPoLines);
+    verifyPut(String.format(INVOICE_ID_PATH, id), JsonObject.mapFrom(reqData), "", 204);
 
-    reqData.setStatus(Invoice.Status.PAID);
-
-    String id = reqData.getId();
-    String jsonBody = JsonObject.mapFrom(reqData).encode();
-
-    verifyPut(String.format(INVOICE_ID_PATH, id), jsonBody, "", 204);
-
-    assertThat(serverRqRs.get(INVOICES, HttpMethod.PUT).get(0).getString(STATUS), is(Invoice.Status.PAID.value()));
-    assertThat(serverRqRs.get(INVOICE_LINES, HttpMethod.GET), notNullValue());
-    assertThat(serverRqRs.get(INVOICE_LINES, HttpMethod.GET).get(0).mapTo(InvoiceLineCollection.class).getTotalRecords(), equalTo(3));
-    assertThat(serverRqRs.get(PO_LINES, HttpMethod.PUT), notNullValue());
-    assertThat(serverRqRs.get(PO_LINES, HttpMethod.PUT), hasSize(3));
-    serverRqRs.get(PO_LINES, HttpMethod.PUT).stream()
+    assertThat(getRqRsEntries(HttpMethod.PUT, INVOICES).get(0).getString(STATUS), is(Invoice.Status.PAID.value()));
+    assertThat(getRqRsEntries(HttpMethod.GET, INVOICE_LINES), hasSize(1));
+    assertThat(getRqRsEntries(HttpMethod.GET, INVOICE_LINES).get(0).mapTo(InvoiceLineCollection.class).getTotalRecords(), equalTo(3));
+    assertThat(getRqRsEntries(HttpMethod.PUT, PO_LINES), hasSize(3));
+    getRqRsEntries(HttpMethod.PUT, PO_LINES).stream()
       .map(entries -> entries.mapTo(CompositePoLine.class))
       .forEach(compositePoLine -> assertThat(compositePoLine.getPaymentStatus(), equalTo(CompositePoLine.PaymentStatus.FULLY_PAID)));
+    assertThatVoucherPaid();
 
   }
 
@@ -669,9 +738,11 @@ public class InvoicesApiTest extends ApiTestBase {
   private void checkNumberOfRequests(Invoice.Status[] statuses) {
     // Invoice status open - expect no GET invoice rq + PUT invoice rq
     for(Invoice.Status status : statuses) {
-      Invoice invoice = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class);
-      invoice.setStatus(status);
+      Invoice invoice = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class).withStatus(status);
+      prepareMockVoucher(invoice.getId());
+
       verifyPut(String.format(INVOICE_ID_PATH, invoice.getId()), JsonObject.mapFrom(invoice).encode(), "", HttpStatus.SC_NO_CONTENT);
+
       assertThat(serverRqRs.row(INVOICES).get(HttpMethod.GET), hasSize(1));
       assertThat(serverRqRs.row(INVOICES).get(HttpMethod.PUT), hasSize(1));
       serverRqRs.clear();

--- a/src/test/java/org/folio/rest/impl/VouchersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/VouchersApiTest.java
@@ -34,7 +34,7 @@ public class VouchersApiTest extends ApiTestBase {
 
   private static final String VOUCHER_PATH = "/voucher/vouchers";
   private static final String VOUCHER_ID_PATH = VOUCHER_PATH + "/%s";
-  private static final String VOUCHERS_LIST_PATH = VOUCHER_MOCK_DATA_PATH + "vouchers.json";
+  static final String VOUCHERS_LIST_PATH = VOUCHER_MOCK_DATA_PATH + "vouchers.json";
   private static final String BAD_VOUCHER_ID = "5a34ae0e-5a11-4337-be95-1a20cfdc3161";
   private static final String INVALID_VOUCHER_ID = "invalidVoucherId";
   private static final String VALID_START_VALUE = "101";


### PR DESCRIPTION
## Purpose
[MODINVOICE-36](https://issues.folio.org/browse/MODINVOICE-36) Mark voucher as paid on transition to invoice status "Paid"

## Approach
- When the invoice's status is being updated to `Paid`:
  - Get voucher by invoice id. If not found, complete flow with `voucherNotFound` error
  - Check voucher's status: 
    - if it is not yet Paid, update status to Paid and store updated voucher. In case f failure complete flow with `voucherUpdateFailure` error
    - otherwise do nothing
- Other improvements:
  - Return `poLineUpdateFailure` error if PO Line's update failed
  - Update `ResourcePathResolver#resourceByIdPath` method adding `lang` param

#### TODOS and Open Questions
- [ ] The logic is based on assumption that voucher is always available when invoice is approved. This is implemented in  https://github.com/folio-org/mod-invoice/pull/36

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
