### PR TITLE
MODORDERS-247 Make contributor-name-type configurable

### DIFF
--- a/src/test/resources/mockdata/poLines/0009662b-8b80-4001-b704-ca10971f175d.json
+++ b/src/test/resources/mockdata/poLines/0009662b-8b80-4001-b704-ca10971f175d.json
@@ -14,7 +14,7 @@
   "contributors": [
     {
       "contributor": "Ed Mashburn",
-      "contributorType": "fbdd42a8-e47d-4694-b448-cc571d1b44c3"
+      "contributorNameTypeId": "fbdd42a8-e47d-4694-b448-cc571d1b44c3"
     }
   ],
   "cost": {

--- a/src/test/resources/mockdata/poLines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
+++ b/src/test/resources/mockdata/poLines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
@@ -14,7 +14,7 @@
   "contributors": [
     {
       "contributor": "Ed Mashburn",
-      "contributorType": "fbdd42a8-e47d-4694-b448-cc571d1b44c3"
+      "contributorNameTypeId": "fbdd42a8-e47d-4694-b448-cc571d1b44c3"
     }
   ],
   "cost": {


### PR DESCRIPTION
## Purpose
[MODORDERS-247](https://issues.folio.org/browse/MODORDERS-247) Make contributor-name-type configurable

#### TODOS and Open Questions
- [x] Merge with folio-org/mod-orders#182
## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
