### PR TITLE
MODINVOICE-87 Calculate and persist totals upon invoice creation/update/get

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -322,48 +322,10 @@
       "visible": false
     },
     {
-      "permissionName": "invoice.acquisitions-units-assignments.assignments.collection.get",
-      "displayName": "Acquisitions unit assignment - get assignments",
-      "description": "Get a collection of acquisitions unit assignments"
-    },
-    {
-      "permissionName": "invoice.acquisitions-units-assignments.assignments.item.post",
-      "displayName": "Acquisitions unit assignment - create unit assignment",
-      "description": "Create a new acquisitions unit assignments"
-    },
-    {
-      "permissionName": "invoice.acquisitions-units-assignments.assignments.item.get",
-      "displayName": "Acquisitions unit assignment - get unit assignment",
-      "description": "Fetch an acquisitions unit assignments"
-    },
-    {
-      "permissionName": "invoice.acquisitions-units-assignments.assignments.item.put",
-      "displayName": "Acquisitions unit assignment - update unit assignment",
-      "description": "Update an acquisitions unit assignments"
-    },
-    {
-      "permissionName": "invoice.acquisitions-units-assignments.assignments.item.delete",
-      "displayName": "Acquisitions units - delete unit",
-      "description": "Delete an acquisitions unit assignments"
-    },
-    {
-      "permissionName": "invoice.acquisitions-units-assignments.assignments.all",
-      "displayName": "All acquisitions-unit-assignments perms",
-      "description": "All permissions for the acquisitions-unit-assignments",
-      "subPermissions": [
-        "invoice.acquisitions-units-assignments.assignments.collection.get",
-        "invoice.acquisitions-units-assignments.assignments.item.post",
-        "invoice.acquisitions-units-assignments.assignments.item.get",
-        "invoice.acquisitions-units-assignments.assignments.item.put",
-        "invoice.acquisitions-units-assignments.assignments.item.delete"
-      ]
-    },
-    {
       "permissionName": "invoice.all",
       "displayName": "Invoice module - all permissions",
       "description": "Entire set of permissions needed to use the invoice module",
       "subPermissions": [
-        "invoice.acquisitions-units-assignments.assignments.all",
         "invoice.invoices.collection.get",
         "invoice.invoices.item.get",
         "invoice.invoices.item.post",

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,12 @@
       <version>${mod-configuration-client.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-di-support</artifactId>
+      <version>1.0.0</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
       <groupId>one.util</groupId>
       <artifactId>streamex</artifactId>
       <version>0.6.8</version>
@@ -73,6 +79,12 @@
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <version>${rest-assured.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>3.1.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -1,0 +1,10 @@
+package org.folio.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan({
+  "org.folio.rest.impl",
+  "org.folio.invoices"})
+public class ApplicationConfig {}

--- a/src/main/java/org/folio/invoices/events/handlers/InvoiceSummary.java
+++ b/src/main/java/org/folio/invoices/events/handlers/InvoiceSummary.java
@@ -1,0 +1,74 @@
+package org.folio.invoices.events.handlers;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static org.folio.invoices.utils.HelperUtils.INVOICE_ID;
+import static org.folio.invoices.utils.HelperUtils.LANG;
+import static org.folio.invoices.utils.HelperUtils.getOkapiHeaders;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.invoices.rest.exceptions.HttpException;
+import org.folio.rest.impl.InvoiceHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+@Component("invoiceSummaryHandler")
+public class InvoiceSummary implements Handler<Message<JsonObject>> {
+  protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+  private final Context ctx;
+
+  @Autowired
+  public InvoiceSummary(Vertx vertx) {
+    ctx = vertx.getOrCreateContext();
+  }
+
+  @Override
+  public void handle(Message<JsonObject> message) {
+    JsonObject body = message.body();
+    Map<String, String> okapiHeaders = getOkapiHeaders(message);
+
+    logger.debug("Received message body: {}", body);
+
+    InvoiceHelper helper = new InvoiceHelper(okapiHeaders, ctx, body.getString(LANG));
+    String invoiceId = body.getString(INVOICE_ID);
+
+    helper.getInvoiceRecord(invoiceId)
+      // To calculate totals, related invoice lines have to be retrieved
+      .thenCompose(invoice -> helper.recalculateTotals(invoice)
+        .thenCompose(isOutOfSync -> {
+          if (isOutOfSync) {
+            logger.debug("The invoice with id={} is out of sync in storage and requires updates", invoiceId);
+            return helper.updateInvoiceRecord(invoice);
+          } else {
+            logger.debug("The invoice with id={} is up to date in storage", invoiceId);
+            return completedFuture(null);
+          }
+        }))
+      .handle((ok, fail) -> {
+        // Sending reply message just in case some logic requires it
+        if (fail == null) {
+          message.reply(Response.Status.OK.getReasonPhrase());
+        } else {
+          Throwable cause = fail.getCause();
+          int code = INTERNAL_SERVER_ERROR.getStatusCode();
+          if (cause instanceof HttpException) {
+            code = ((HttpException) cause).getCode();
+          }
+          message.fail(code, cause.getMessage());
+        }
+        helper.closeHttpClient();
+        return null;
+      });
+  }
+}

--- a/src/main/java/org/folio/invoices/events/handlers/MessageAddress.java
+++ b/src/main/java/org/folio/invoices/events/handlers/MessageAddress.java
@@ -1,0 +1,12 @@
+package org.folio.invoices.events.handlers;
+
+public enum MessageAddress {
+
+  INVOICE_TOTALS("org.folio.invoices.invoice.update.totals");
+
+  MessageAddress(String address) {
+    this.address = address;
+  }
+
+  public final String address;
+}

--- a/src/main/java/org/folio/invoices/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/invoices/utils/ErrorCodes.java
@@ -17,8 +17,7 @@ public enum ErrorCodes {
   PROHIBITED_FIELD_CHANGING("protectedFieldChanging", "Field can't be modified"),
   FUNDS_NOT_FOUND("fundsNotFound", "Fund records are not found"),
   VOUCHER_NUMBER_PREFIX_NOT_ALPHA("voucherNumberPrefixNotAlpha", "Voucher number prefix must contains only Unicode letters"),
-  PROHIBITED_INVOICE_LINE_CREATION("prohibitedInvoiceLineCreation","It is not allowed to add invoice line to the invoice that has been approved"),
-  MISMATCH_BETWEEN_ID_IN_PATH_AND_BODY("idMismatch", "Mismatch between id in path and request body");
+  PROHIBITED_INVOICE_LINE_CREATION("prohibitedInvoiceLineCreation","It is not allowed to add invoice line to the invoice that has been approved");
 
   private final String code;
   private final String description;

--- a/src/main/java/org/folio/rest/impl/InitAPIs.java
+++ b/src/main/java/org/folio/rest/impl/InitAPIs.java
@@ -1,0 +1,50 @@
+package org.folio.rest.impl;
+
+import org.folio.config.ApplicationConfig;
+import org.folio.rest.resource.interfaces.InitAPI;
+import org.folio.rest.tools.utils.ObjectMapperTool;
+import org.folio.spring.SpringContextUtil;
+
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.SerializationConfig;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+/**
+ * The class initializes vertx context adding spring context
+ */
+public class InitAPIs implements InitAPI {
+  private final Logger logger = LoggerFactory.getLogger(InitAPIs.class);
+
+  @Override
+  public void init(Vertx vertx, Context context, Handler<AsyncResult<Boolean>> resultHandler) {
+    vertx.executeBlocking(
+      handler -> {
+        SerializationConfig serializationConfig = ObjectMapperTool.getMapper().getSerializationConfig();
+        DeserializationConfig deserializationConfig = ObjectMapperTool.getMapper().getDeserializationConfig();
+
+        Json.mapper.setConfig(serializationConfig);
+        Json.prettyMapper.setConfig(serializationConfig);
+        Json.mapper.setConfig(deserializationConfig);
+        Json.prettyMapper.setConfig(deserializationConfig);
+
+        SpringContextUtil.init(vertx, context, ApplicationConfig.class);
+        handler.complete();
+      },
+      result -> {
+        if (result.succeeded()) {
+          resultHandler.handle(Future.succeededFuture(true));
+        } else {
+          logger.error("Failure to init API", result.cause());
+          resultHandler.handle(Future.failedFuture(result.cause()));
+        }
+      });
+  }
+}

--- a/src/main/java/org/folio/rest/impl/InitEventBus.java
+++ b/src/main/java/org/folio/rest/impl/InitEventBus.java
@@ -1,0 +1,63 @@
+package org.folio.rest.impl;
+
+import org.folio.invoices.events.handlers.MessageAddress;
+import org.folio.rest.resource.interfaces.PostDeployVerticle;
+import org.folio.spring.SpringContextUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+/**
+ * The class initializes event bus handlers
+ */
+public class InitEventBus implements PostDeployVerticle {
+  private final Logger logger = LoggerFactory.getLogger(InitEventBus.class);
+
+  @Autowired
+  @Qualifier("invoiceSummaryHandler")
+  Handler<Message<JsonObject>> orderStatusHandler;
+
+  public InitEventBus() {
+    SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
+  }
+
+  @Override
+  public void init(Vertx vertx, Context context, Handler<AsyncResult<Boolean>> resultHandler) {
+    vertx.executeBlocking(blockingCodeFuture -> {
+      EventBus eb = vertx.eventBus();
+
+      // Create consumers and assign handlers
+      Future<Void> invoiceSummaryRegistrationHandler = Future.future();
+
+      MessageConsumer<JsonObject> invoiceSummaryConsumer = eb.localConsumer(MessageAddress.INVOICE_TOTALS.address);
+      invoiceSummaryConsumer.handler(orderStatusHandler)
+        .completionHandler(invoiceSummaryRegistrationHandler);
+
+      invoiceSummaryRegistrationHandler.setHandler(result -> {
+        if (result.succeeded()) {
+          blockingCodeFuture.complete();
+        } else {
+          blockingCodeFuture.fail(result.cause());
+        }
+      });
+    }, result -> {
+      if (result.succeeded()) {
+        resultHandler.handle(Future.succeededFuture(true));
+      } else {
+        logger.error(result.cause());
+        resultHandler.handle(Future.failedFuture(result.cause()));
+      }
+    });
+  }
+}

--- a/src/main/java/org/folio/rest/impl/InvoiceLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/InvoiceLineHelper.java
@@ -1,8 +1,6 @@
 package org.folio.rest.impl;
 
 import static io.vertx.core.json.JsonObject.mapFrom;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.folio.invoices.utils.ErrorCodes.PROHIBITED_INVOICE_LINE_CREATION;
 import static org.folio.invoices.utils.HelperUtils.*;
 import static org.folio.invoices.utils.ResourcePathResolver.INVOICE_LINES;

--- a/src/main/java/org/folio/rest/impl/InvoicesImpl.java
+++ b/src/main/java/org/folio/rest/impl/InvoicesImpl.java
@@ -175,12 +175,6 @@ public class InvoicesImpl implements org.folio.rest.jaxrs.resource.Invoice {
     }
   }
 
-  private void logInfo(String message, String id) {
-    if (logger.isInfoEnabled()) {
-      logger.info(message, id);
-    }
-  }
-
   private Void handleErrorResponse(Handler<AsyncResult<Response>> asyncResultHandler, AbstractHelper helper, Throwable t) {
     asyncResultHandler.handle(succeededFuture(helper.buildErrorResponse(t)));
     return null;

--- a/src/main/java/org/folio/rest/impl/VoucherHelper.java
+++ b/src/main/java/org/folio/rest/impl/VoucherHelper.java
@@ -38,7 +38,7 @@ public class VoucherHelper extends AbstractHelper {
   }
 
   VoucherHelper(Map<String, String> okapiHeaders, Context ctx, String lang) {
-    super(getHttpClient(okapiHeaders), okapiHeaders, ctx, lang);
+    super(okapiHeaders, ctx, lang);
   }
 
   public CompletableFuture<Voucher> getVoucher(String id) {
@@ -60,7 +60,7 @@ public class VoucherHelper extends AbstractHelper {
     return handleGetRequest(resourcesPath(VOUCHER_NUMBER_START), httpClient, ctx, okapiHeaders, logger)
       .thenApply(entry -> entry.mapTo(SequenceNumber.class));
   }
-  
+
   /**
    * This endpoint is a means for the UI to set/reset the start value of the voucher-number sequence
    * @param value start value to be set/reset
@@ -100,7 +100,7 @@ public class VoucherHelper extends AbstractHelper {
     }
     return future;
   }
-  
+
   /**
    * Gets list of voucher
    *

--- a/src/main/java/org/folio/rest/impl/VoucherLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/VoucherLineHelper.java
@@ -25,7 +25,7 @@ public class VoucherLineHelper extends AbstractHelper {
   private static final String GET_VOUCHER_LINE_BY_QUERY = resourcesPath(VOUCHER_LINES) + "?limit=%s&offset=%s%s&lang=%s";
 
   VoucherLineHelper(Map<String, String> okapiHeaders, Context ctx, String lang) {
-    super(getHttpClient(okapiHeaders), okapiHeaders, ctx, lang);
+    super(okapiHeaders, ctx, lang);
   }
 
   VoucherLineHelper(HttpClientInterface httpClient, Map<String, String> okapiHeaders, Context ctx, String lang) {

--- a/src/test/java/org/folio/invoices/events/handlers/InvoiceSummaryTest.java
+++ b/src/test/java/org/folio/invoices/events/handlers/InvoiceSummaryTest.java
@@ -1,0 +1,147 @@
+package org.folio.invoices.events.handlers;
+
+import static org.folio.invoices.utils.HelperUtils.INVOICE_ID;
+import static org.folio.invoices.utils.ResourcePathResolver.INVOICES;
+import static org.folio.rest.impl.InvoicesApiTest.OPEN_INVOICE_ID;
+import static org.folio.rest.impl.InvoicesApiTest.OPEN_INVOICE_SAMPLE_PATH;
+import static org.folio.rest.impl.MockServer.getInvoiceLineSearches;
+import static org.folio.rest.impl.MockServer.getInvoiceRetrievals;
+import static org.folio.rest.impl.MockServer.getInvoiceUpdates;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.impl.ApiTestBase;
+import org.folio.rest.impl.MockServer;
+import org.folio.rest.jaxrs.model.Invoice;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class InvoiceSummaryTest extends ApiTestBase {
+  private static final Logger logger = LoggerFactory.getLogger(InvoiceSummaryTest.class);
+
+  private static final String TEST_ADDRESS = "testAddress";
+
+  private static Vertx vertx;
+
+  @BeforeClass
+  public static void before() throws InterruptedException, ExecutionException, TimeoutException {
+    ApiTestBase.before();
+
+    vertx = Vertx.vertx();
+    vertx.eventBus().consumer(TEST_ADDRESS, new InvoiceSummary(vertx));
+  }
+
+  @Test
+  public void testUpdateInvoiceTotals(TestContext context) {
+    logger.info("=== Test case when invoice summary update is expected due to sub-total change ===");
+
+    Invoice invoice = getMockAsJson(OPEN_INVOICE_SAMPLE_PATH).mapTo(Invoice.class);
+    invoice.setAdjustmentsTotal(5d);
+    invoice.setSubTotal(10d);
+    invoice.setTotal(15d);
+    MockServer.addMockEntry(INVOICES, invoice);
+
+    sendEvent(createBody(OPEN_INVOICE_ID), context.asyncAssertSuccess(result -> {
+      assertThat(getInvoiceRetrievals(), hasSize(1));
+      assertThat(getInvoiceLineSearches(), hasSize(1));
+      assertThat(getInvoiceUpdates(), hasSize(1));
+
+      Invoice updatedInvoice = getInvoiceUpdates().get(0).mapTo(Invoice.class);
+      assertThat(updatedInvoice.getAdjustmentsTotal(), not(invoice.getAdjustmentsTotal()));
+      assertThat(updatedInvoice.getSubTotal(), not(invoice.getSubTotal()));
+      assertThat(updatedInvoice.getTotal(), not(invoice.getTotal()));
+      assertThat(result.body(), equalTo(Response.Status.OK.getReasonPhrase()));
+    }));
+  }
+
+  @Test
+  public void testUpdateInvoiceTotalsNoLines(TestContext context) {
+    logger.info("=== Test case when invoice summary update is expected when no lines found ===");
+
+    // Setting non zero values which should be resulted to zeros
+    Invoice invoice = new Invoice().withId(VALID_UUID)
+      .withAdjustmentsTotal(5d)
+      .withSubTotal(10d)
+      .withTotal(15d)
+      .withCurrency("USD");
+    MockServer.addMockEntry(INVOICES, invoice);
+
+    sendEvent(createBody(VALID_UUID), context.asyncAssertSuccess(result -> {
+      assertThat(getInvoiceRetrievals(), hasSize(1));
+      assertThat(getInvoiceLineSearches(), hasSize(1));
+      assertThat(getInvoiceUpdates(), hasSize(1));
+
+      Invoice updatedInvoice = getInvoiceUpdates().get(0).mapTo(Invoice.class);
+      assertThat(updatedInvoice.getAdjustmentsTotal(), is(0d));
+      assertThat(updatedInvoice.getSubTotal(), is(0d));
+      assertThat(updatedInvoice.getTotal(), is(0d));
+      assertThat(result.body(), equalTo(Response.Status.OK.getReasonPhrase()));
+    }));
+  }
+
+  @Test
+  public void testUpdateNotRequired(TestContext context) {
+    logger.info("=== Test case when no invoice update is expected ===");
+
+    Invoice invoice = new Invoice().withId(VALID_UUID)
+      .withAdjustmentsTotal(0d)
+      .withSubTotal(0d)
+      .withTotal(0d)
+      .withCurrency("USD");
+    MockServer.addMockEntry(INVOICES, invoice);
+
+    sendEvent(createBody(VALID_UUID), context.asyncAssertSuccess(result -> {
+      assertThat(getInvoiceRetrievals(), hasSize(1));
+      assertThat(getInvoiceLineSearches(), hasSize(1));
+      assertThat(getInvoiceUpdates(), empty());
+      assertThat(result.body(), equalTo(Response.Status.OK.getReasonPhrase()));
+    }));
+  }
+
+  @Test
+  public void testNonexistentInvoice(TestContext context) {
+    logger.info("=== Test case when invoice is not found ===");
+    sendEvent(createBody(ID_DOES_NOT_EXIST), context.asyncAssertFailure(result -> {
+      assertThat(getInvoiceRetrievals(), empty());
+      assertThat(getInvoiceLineSearches(), empty());
+      assertThat(getInvoiceUpdates(), empty());
+      assertThat(result, instanceOf(ReplyException.class));
+      assertThat(((ReplyException) result).failureCode(), is(404));
+    }));
+  }
+
+  private JsonObject createBody(String id) {
+    return new JsonObject().put(INVOICE_ID, id);
+  }
+
+  private void sendEvent(JsonObject data, Handler<AsyncResult<Message<String>>> replyHandler) {
+    // Add okapi url header
+    DeliveryOptions deliveryOptions = new DeliveryOptions().addHeader(X_OKAPI_URL.getName(), X_OKAPI_URL.getValue());
+
+    vertx.eventBus().send(TEST_ADDRESS, data, deliveryOptions, replyHandler);
+  }
+}

--- a/src/test/java/org/folio/rest/impl/ApiTestBase.java
+++ b/src/test/java/org/folio/rest/impl/ApiTestBase.java
@@ -4,41 +4,62 @@ import io.restassured.RestAssured;
 import io.restassured.http.Header;
 import io.restassured.http.Headers;
 import io.restassured.response.Response;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+
 import org.apache.commons.io.IOUtils;
+import org.folio.invoices.events.handlers.MessageAddress;
+import org.folio.invoices.utils.HelperUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.awaitility.Awaitility.await;
+import static org.folio.invoices.utils.HelperUtils.INVOICE_ID;
+import static org.folio.invoices.utils.HelperUtils.OKAPI_URL;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
 import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
-import static org.folio.rest.impl.AbstractHelper.OKAPI_URL;
 import static org.folio.rest.impl.ApiTestSuite.mockPort;
+import static org.folio.rest.impl.InvoiceLinesApiTest.INVOICE_LINES_PATH;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.fail;
 
 public class ApiTestBase {
 
-  static final String VALID_UUID = "8d3881f6-dd93-46f0-b29d-1c36bdb5c9f9";
+  public static final String VALID_UUID = "8d3881f6-dd93-46f0-b29d-1c36bdb5c9f9";
   static final String ID_BAD_FORMAT = "123-45-678-90-abc";
   static final String FOLIO_INVOICE_NUMBER_VALUE = "228D126";
-  static final Header X_OKAPI_URL = new Header(OKAPI_URL, "http://localhost:" + mockPort);
+  public static final Header X_OKAPI_URL = new Header(OKAPI_URL, "http://localhost:" + mockPort);
   static final Header X_OKAPI_TOKEN = new Header(OKAPI_HEADER_TOKEN, "eyJhbGciOiJIUzI1NiJ9");
   static final Header X_OKAPI_TENANT = new Header(OKAPI_HEADER_TENANT, "invoiceimpltest");
   static final Header X_OKAPI_USERID = new Header(OKAPI_USERID_HEADER, "d1d0a10b-c563-4c4b-ae22-e5a0c11623eb");
-  static final String X_ECHO_STATUS = "X-Okapi-Echo-Status";
 
   static final String BASE_MOCK_DATA_PATH = "mockdata/";
 
@@ -47,7 +68,7 @@ public class ApiTestBase {
   static final String LANG_PARAM = "lang";
   static final String INVALID_LANG = "english";
 
-  static final String ID_DOES_NOT_EXIST = "d25498e7-3ae6-45fe-9612-ec99e2700d2f";
+  public static final String ID_DOES_NOT_EXIST = "d25498e7-3ae6-45fe-9612-ec99e2700d2f";
   static final String ID_FOR_INTERNAL_SERVER_ERROR = "168f8a86-d26c-406e-813f-c7527f241ac3";
   static final String ID_FOR_INTERNAL_SERVER_ERROR_PUT = "bad500bb-bbbb-500b-bbbb-bbbbbbbbbbbb";
 
@@ -59,6 +80,26 @@ public class ApiTestBase {
 
 
   private static boolean runningOnOwn;
+
+  // The variable is defined in main thread but the value is going to be inserted in vert.x event loop thread
+  private static volatile List<Message<JsonObject>> eventMessages = new ArrayList<>();
+
+  /**
+   * Define unit test specific beans to override actual ones
+   */
+  @Configuration
+  static class ContextConfiguration {
+
+    @Bean("invoiceSummaryHandler")
+    @Primary
+    public Handler<Message<JsonObject>> mockedInvoiceSummaryHandler() {
+      // As an implementation just add received message to list
+      return message -> {
+        logger.info("New message sent to {} address: {}", message.address(), message.body());
+        eventMessages.add(message);
+      };
+    }
+  }
 
   @BeforeClass
   public static void before() throws InterruptedException, ExecutionException, TimeoutException {
@@ -72,6 +113,11 @@ public class ApiTestBase {
 
   @Before
   public void setUp() {
+    clearServiceInteractions();
+  }
+
+  protected void clearServiceInteractions() {
+    eventMessages.clear();
     MockServer.serverRqRs.clear();
   }
 
@@ -99,7 +145,7 @@ public class ApiTestBase {
     }
   }
 
-  JsonObject getMockAsJson(String fullPath) {
+  public JsonObject getMockAsJson(String fullPath) {
     try {
       return new JsonObject(getMockData(fullPath));
     } catch (IOException e) {
@@ -113,7 +159,7 @@ public class ApiTestBase {
   }
 
   Response verifyPostResponse(String url, String body, Headers headers, String expectedContentType, int expectedCode) {
-    return RestAssured
+    Response response = RestAssured
       .with()
         .header(X_OKAPI_URL)
         .header(X_OKAPI_TOKEN)
@@ -128,6 +174,11 @@ public class ApiTestBase {
           .contentType(expectedContentType)
           .extract()
             .response();
+
+    int msgQty = (201 == expectedCode && url.startsWith(INVOICE_LINES_PATH)) ? 1 : 0;
+    verifyInvoiceSummaryUpdateEvent(msgQty);
+
+    return response;
   }
 
   Response verifyPut(String url, String body, String expectedContentType, int expectedCode) {
@@ -161,7 +212,7 @@ public class ApiTestBase {
   }
 
   Response verifyGet(String url, Headers headers, String expectedContentType, int expectedCode) {
-    return RestAssured
+    Response response = RestAssured
       .with()
         .headers(headers)
       .get(url)
@@ -171,6 +222,11 @@ public class ApiTestBase {
         .contentType(expectedContentType)
         .extract()
           .response();
+
+    // No events are expected for any GET operations
+    verifyInvoiceSummaryUpdateEvent(0);
+
+    return response;
   }
 
   <T> T verifySuccessGet(String url, Class<T> clazz) {
@@ -183,7 +239,7 @@ public class ApiTestBase {
   }
 
   Response verifyDeleteResponse(String url, Headers headers, String expectedContentType, int expectedCode) {
-    return RestAssured
+    Response response = RestAssured
       .with()
         .headers(headers)
       .delete(url)
@@ -192,10 +248,31 @@ public class ApiTestBase {
           .contentType(expectedContentType)
           .extract()
             .response();
+
+    int msgQty = (204 == expectedCode && url.startsWith(INVOICE_LINES_PATH)) ? 1 : 0;
+    verifyInvoiceSummaryUpdateEvent(msgQty);
+
+    return response;
   }
 
   Headers prepareHeaders(Header... headers) {
     return new Headers(headers);
+  }
+
+  void verifyInvoiceSummaryUpdateEvent(int msgQty) {
+    logger.debug("Verifying event bus messages");
+    // Wait until event bus registers message
+    await().atLeast(50, MILLISECONDS)
+      .atMost(1, SECONDS)
+      .until(() -> eventMessages, hasSize(msgQty));
+    for (int i = 0; i < msgQty; i++) {
+      Message<JsonObject> message = eventMessages.get(i);
+      assertThat(message.address(), equalTo(MessageAddress.INVOICE_TOTALS.address));
+      assertThat(message.headers(), not(emptyIterable()));
+      assertThat(message.body(), notNullValue());
+      assertThat(message.body().getString(INVOICE_ID), not(isEmptyOrNullString()));
+      assertThat(message.body().getString(HelperUtils.LANG), not(isEmptyOrNullString()));
+    }
   }
 
 }

--- a/src/test/java/org/folio/rest/impl/ApiTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/ApiTestSuite.java
@@ -4,6 +4,8 @@ import io.restassured.RestAssured;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+
+import org.folio.invoices.events.handlers.InvoiceSummaryTest;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.AfterClass;
@@ -21,7 +23,8 @@ import java.util.concurrent.TimeoutException;
   InvoicesApiTest.class,
   InvoiceLinesApiTest.class,
   VouchersApiTest.class,
-  VoucherLinesApiTest.class
+  VoucherLinesApiTest.class,
+  InvoiceSummaryTest.class
 })
 public class ApiTestSuite {
 

--- a/src/test/java/org/folio/rest/impl/InvoiceLinesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoiceLinesApiTest.java
@@ -33,6 +33,7 @@ import static org.folio.rest.impl.InvoicesApiTest.OPEN_INVOICE_ID;
 import static org.folio.rest.impl.InvoicesApiTest.REVIEWED_INVOICE_ID;
 import static org.folio.rest.impl.InvoicesImpl.PROTECTED_AND_MODIFIED_FIELDS;
 import static org.folio.rest.impl.MockServer.INVOICE_LINE_NUMBER_ERROR_X_OKAPI_TENANT;
+import static org.folio.rest.impl.MockServer.addMockEntry;
 import static org.folio.rest.impl.MockServer.serverRqRs;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
@@ -49,7 +50,7 @@ public class InvoiceLinesApiTest extends ApiTestBase {
 
   static final String INVOICE_LINES_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "invoiceLines/";
   static final String INVOICE_LINES_LIST_PATH = INVOICE_LINES_MOCK_DATA_PATH + "invoice_lines.json";
-  private static final String INVOICE_LINES_PATH = "/invoice/invoice-lines";
+  static final String INVOICE_LINES_PATH = "/invoice/invoice-lines";
   private static final String INVOICE_LINE_ID_PATH = INVOICE_LINES_PATH + "/%s";
 
 
@@ -118,6 +119,7 @@ public class InvoiceLinesApiTest extends ApiTestBase {
   public void deleteInvoicingInvoiceLinesByIdTest() {
     logger.info("=== Test delete invoice line by id ===");
 
+    addMockEntry(INVOICE_LINES, JsonObject.mapFrom(new InvoiceLine().withId(VALID_UUID).withInvoiceId(VALID_UUID)));
     verifyDeleteResponse(String.format(INVOICE_LINE_ID_PATH, VALID_UUID), "", 204);
   }
 
@@ -209,6 +211,8 @@ public class InvoiceLinesApiTest extends ApiTestBase {
     String reqData = getMockData(INVOICE_LINES_MOCK_DATA_PATH + INVOICE_LINE_WITH_APPROVED_EXISTED_INVOICE_ID + ".json");
 
     verifyPut(String.format(INVOICE_LINE_ID_PATH, INVOICE_LINE_WITH_APPROVED_EXISTED_INVOICE_ID), reqData, "", 204);
+
+    verifyInvoiceSummaryUpdateEvent(1);
   }
 
   @Test
@@ -216,6 +220,8 @@ public class InvoiceLinesApiTest extends ApiTestBase {
     String reqData = getMockData(INVOICE_LINES_MOCK_DATA_PATH + INVOICE_LINE_WITH_INTERNAL_ERROR_ON_GET_INVOICE + ".json");
 
     verifyPut(String.format(INVOICE_LINE_ID_PATH, INVOICE_LINE_WITH_APPROVED_EXISTED_INVOICE_ID), reqData, APPLICATION_JSON, 500);
+
+    verifyInvoiceSummaryUpdateEvent(0);
   }
 
   @Test
@@ -224,8 +230,9 @@ public class InvoiceLinesApiTest extends ApiTestBase {
     reqData.setId(ID_DOES_NOT_EXIST);
     String jsonBody = JsonObject.mapFrom(reqData).encode();
 
-    verifyPut(String.format(INVOICE_LINE_ID_PATH, ID_DOES_NOT_EXIST), jsonBody,
-        APPLICATION_JSON, 404);
+    verifyPut(String.format(INVOICE_LINE_ID_PATH, ID_DOES_NOT_EXIST), jsonBody, APPLICATION_JSON, 404);
+
+    verifyInvoiceSummaryUpdateEvent(0);
   }
 
   @Test
@@ -235,6 +242,8 @@ public class InvoiceLinesApiTest extends ApiTestBase {
     String jsonBody = JsonObject.mapFrom(reqData).encode();
 
     verifyPut(String.format(INVOICE_LINE_ID_PATH, ID_FOR_INTERNAL_SERVER_ERROR), jsonBody, APPLICATION_JSON, 500);
+
+    verifyInvoiceSummaryUpdateEvent(0);
   }
 
   @Test
@@ -244,6 +253,8 @@ public class InvoiceLinesApiTest extends ApiTestBase {
     String jsonBody = JsonObject.mapFrom(reqData).encode();
 
     verifyPut(String.format(INVOICE_LINE_ID_PATH, ID_BAD_FORMAT), jsonBody, APPLICATION_JSON, 422);
+
+    verifyInvoiceSummaryUpdateEvent(0);
   }
 
   @Test
@@ -254,6 +265,7 @@ public class InvoiceLinesApiTest extends ApiTestBase {
 
     verifyPut(endpoint, reqData, TEXT_PLAIN, 400);
 
+    verifyInvoiceSummaryUpdateEvent(0);
   }
 
   @Test
@@ -423,8 +435,9 @@ public class InvoiceLinesApiTest extends ApiTestBase {
       MatcherAssert.assertThat(serverRqRs.row(INVOICE_LINES).get(HttpMethod.GET), hasSize(1));
       MatcherAssert.assertThat(serverRqRs.row(INVOICES).get(HttpMethod.GET), hasSize(1));
       MatcherAssert.assertThat(serverRqRs.row(INVOICE_LINES).get(HttpMethod.PUT), hasSize(1));
-      serverRqRs.clear();
 
+    verifyInvoiceSummaryUpdateEvent(1);
+    clearServiceInteractions();
   }
 
   @Test
@@ -436,9 +449,15 @@ public class InvoiceLinesApiTest extends ApiTestBase {
     invoiceLine.setId(INVOICE_LINE_WITH_APPROVED_EXISTED_INVOICE_ID);
     verifyPut(String.format(INVOICE_LINE_ID_PATH, invoiceLine.getId()), JsonObject.mapFrom(invoiceLine).encode(), "", HttpStatus.SC_NO_CONTENT);
 
+    verifyInvoiceSummaryUpdateEvent(1);
+    clearServiceInteractions();
+
     // Invoice line updated (invoice status = OPEN) - protected field not modified
     invoiceLine.setId(INVOICE_LINE_WITH_OPEN_EXISTED_INVOICE_ID);
     verifyPut(String.format(INVOICE_LINE_ID_PATH, invoiceLine.getId()), JsonObject.mapFrom(invoiceLine).encode(), "", HttpStatus.SC_NO_CONTENT);
+
+    verifyInvoiceSummaryUpdateEvent(1);
+    clearServiceInteractions();
 
     // Invoice line updated (invoice status = APPROVED) - all protected fields modified
 
@@ -485,5 +504,7 @@ public class InvoiceLinesApiTest extends ApiTestBase {
     Object[] expected = updatedFields.keySet().stream().map(InvoiceLineProtectedFields::getFieldName).toArray();
     MatcherAssert.assertThat(failedFieldNames.length, is(expected.length));
     MatcherAssert.assertThat(expected, Matchers.arrayContainingInAnyOrder(failedFieldNames));
+
+    verifyInvoiceSummaryUpdateEvent(0);
   }
 }

--- a/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
@@ -110,16 +110,16 @@ public class InvoicesApiTest extends ApiTestBase {
   private static final String INVOICE_ID_WITH_LANG_PATH = INVOICE_ID_PATH + "?lang=%s";
   private static final String INVOICE_PATH_BAD = "/invoice/bad";
   private static final String INVOICE_NUMBER_PATH = "/invoice/invoice-number";
-  static final String INVOICE_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "invoices/";
+  public static final String INVOICE_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "invoices/";
   private static final String PO_LINE_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "poLines/";
   static final String APPROVED_INVOICE_ID = "c0d08448-347b-418a-8c2f-5fb50248d67e";
   static final String REVIEWED_INVOICE_ID = "3773625a-dc0d-4a2d-959e-4a91ee265d67";
-  static final String OPEN_INVOICE_ID = "52fd6ec7-ddc3-4c53-bc26-2779afc27136";
+  public static final String OPEN_INVOICE_ID = "52fd6ec7-ddc3-4c53-bc26-2779afc27136";
   private static final String APPROVED_INVOICE_SAMPLE_PATH = INVOICE_MOCK_DATA_PATH + APPROVED_INVOICE_ID + ".json";
   private static final String REVIEWED_INVOICE_SAMPLE_PATH = INVOICE_MOCK_DATA_PATH + REVIEWED_INVOICE_ID + ".json";
   private static final String REVIEWED_INVOICE_WITH_EXISTING_VOUCHER_SAMPLE_PATH = INVOICE_MOCK_DATA_PATH + "402d0d32-7377-46a7-86ab-542b5684506e.json";
 
-  private static final String OPEN_INVOICE_SAMPLE_PATH = INVOICE_MOCK_DATA_PATH + OPEN_INVOICE_ID + ".json";
+  public static final String OPEN_INVOICE_SAMPLE_PATH = INVOICE_MOCK_DATA_PATH + OPEN_INVOICE_ID + ".json";
   private static final String OPEN_INVOICE_WITH_APPROVED_FILEDS_SAMPLE_PATH = INVOICE_MOCK_DATA_PATH + "d3e13ed1-59da-4f70-bba3-a140e11d30f3.json";
 
   static final String BAD_QUERY = "unprocessableQuery";
@@ -1301,7 +1301,7 @@ public class InvoicesApiTest extends ApiTestBase {
 
       assertThat(serverRqRs.row(INVOICES).get(HttpMethod.GET), hasSize(1));
       assertThat(serverRqRs.row(INVOICES).get(HttpMethod.PUT), hasSize(1));
-      serverRqRs.clear();
+      clearServiceInteractions();
     }
   }
 
@@ -1323,8 +1323,6 @@ public class InvoicesApiTest extends ApiTestBase {
     Headers headers = prepareHeaders(X_OKAPI_TENANT, X_OKAPI_USERID);
 
     verifyPut(String.format(INVOICE_ID_PATH, invoice.getId()), JsonObject.mapFrom(invoice).encode(), headers, APPLICATION_JSON, HttpStatus.SC_UNPROCESSABLE_ENTITY);
-
-    serverRqRs.clear();
   }
 
   @Test


### PR DESCRIPTION
## Purpose
[MODINVOICE-87](https://issues.folio.org/browse/MODINVOICE-87) Calculate and persist totals upon invoice creation/update/get

## Approach
- Updating invoice totals before storing it in DB on `POST`, `PUT` operations
- Updating invoice totals and storing it async (without blocking main operation) in DB on `GET` invoice by id operations if out of sync
- When invoice line is created, updated or deleted an event is triggered to update invoice totals

***Note:*** the acq unit assignments permissions are removed because they are not needed anymore

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [x] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.