### PR TITLE
MODINVOICE-87 Calculate and persist invoice totals upon invoice line creation/update/delete

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -31,6 +31,7 @@
           ],
           "modulePermissions": [
             "invoice-storage.invoices.item.get",
+            "invoice-storage.invoices.item.put",
             "invoice-storage.invoice-lines.collection.get"
           ]
         },
@@ -78,7 +79,9 @@
           "modulePermissions": [
             "invoice-storage.invoice-line-number.get",
             "invoice-storage.invoices.item.get",
-            "invoice-storage.invoice-lines.item.post"
+            "invoice-storage.invoices.item.put",
+            "invoice-storage.invoice-lines.item.post",
+            "invoice-storage.invoice-lines.collection.get"
           ]
         },
         {
@@ -95,16 +98,24 @@
           "pathPattern": "/invoice/invoice-lines/{id}",
           "permissionsRequired": ["invoice.invoice-lines.item.put"],
           "modulePermissions": [
-              "invoice-storage.invoice-lines.item.put",
-              "invoice-storage.invoice-lines.item.get",
-              "invoice-storage.invoices.item.get"
+            "invoice-storage.invoice-lines.item.put",
+            "invoice-storage.invoice-lines.item.get",
+            "invoice-storage.invoice-lines.collection.get",
+            "invoice-storage.invoices.item.get",
+            "invoice-storage.invoices.item.put"
           ]
         },
         {
           "methods": ["DELETE"],
           "pathPattern": "/invoice/invoice-lines/{id}",
           "permissionsRequired": ["invoice.invoice-lines.item.delete"],
-          "modulePermissions": ["invoice-storage.invoice-lines.item.delete"]
+          "modulePermissions": [
+            "invoice-storage.invoice-lines.item.get",
+            "invoice-storage.invoice-lines.item.delete",
+            "invoice-storage.invoice-lines.collection.get",
+            "invoice-storage.invoices.item.get",
+            "invoice-storage.invoices.item.put"
+          ]
         },
         {
           "methods": ["GET"],


### PR DESCRIPTION
## Purpose
[MODINVOICE-87](https://issues.folio.org/browse/MODINVOICE-87) Calculate and persist invoice totals

## Approach
This is follow on changes to https://github.com/folio-org/mod-invoice/pull/55: update module permission to let async invoice update to work when invoice line totals are changed

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [x] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.