### PR TITLE
MODINVOICE-87 Calculate and persist invoice totals upon invoice line updates

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -90,8 +90,10 @@
           "permissionsRequired": ["invoice.invoice-lines.item.get"],
           "modulePermissions": [
             "invoice-storage.invoice-lines.item.get",
+            "invoice-storage.invoice-lines.item.put",
+            "invoice-storage.invoice-lines.collection.get",
             "invoice-storage.invoices.item.get",
-            "invoice-storage.invoice-lines.item.put"
+            "invoice-storage.invoices.item.put"
           ]
         },
         {

--- a/src/main/java/org/folio/invoices/events/handlers/InvoiceSummary.java
+++ b/src/main/java/org/folio/invoices/events/handlers/InvoiceSummary.java
@@ -2,16 +2,19 @@ package org.folio.invoices.events.handlers;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static org.folio.invoices.utils.HelperUtils.INVOICE;
 import static org.folio.invoices.utils.HelperUtils.INVOICE_ID;
 import static org.folio.invoices.utils.HelperUtils.LANG;
 import static org.folio.invoices.utils.HelperUtils.getOkapiHeaders;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import javax.ws.rs.core.Response;
 
 import org.folio.invoices.rest.exceptions.HttpException;
 import org.folio.rest.impl.InvoiceHelper;
+import org.folio.rest.jaxrs.model.Invoice;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -22,6 +25,7 @@ import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 
 @Component("invoiceSummaryHandler")
 public class InvoiceSummary implements Handler<Message<JsonObject>> {
@@ -41,17 +45,15 @@ public class InvoiceSummary implements Handler<Message<JsonObject>> {
     logger.debug("Received message body: {}", body);
 
     InvoiceHelper helper = new InvoiceHelper(okapiHeaders, ctx, body.getString(LANG));
-    String invoiceId = body.getString(INVOICE_ID);
 
-    helper.getInvoiceRecord(invoiceId)
-      // To calculate totals, related invoice lines have to be retrieved
+    getInvoiceRecord(helper, body)
       .thenCompose(invoice -> helper.recalculateTotals(invoice)
         .thenCompose(isOutOfSync -> {
           if (isOutOfSync) {
-            logger.debug("The invoice with id={} is out of sync in storage and requires updates", invoiceId);
+            logger.debug("The invoice with id={} is out of sync in storage and requires updates", invoice.getId());
             return helper.updateInvoiceRecord(invoice);
           } else {
-            logger.debug("The invoice with id={} is up to date in storage", invoiceId);
+            logger.debug("The invoice with id={} is up to date in storage", invoice.getId());
             return completedFuture(null);
           }
         }))
@@ -70,5 +72,13 @@ public class InvoiceSummary implements Handler<Message<JsonObject>> {
         helper.closeHttpClient();
         return null;
       });
+  }
+
+  private CompletableFuture<Invoice> getInvoiceRecord(InvoiceHelper helper, JsonObject body) {
+    if (body.containsKey(INVOICE)) {
+      return VertxCompletableFuture.supplyAsync(ctx, () -> body.getJsonObject(INVOICE).mapTo(Invoice.class));
+    } else {
+      return helper.getInvoiceRecord(body.getString(INVOICE_ID));
+    }
   }
 }

--- a/src/main/java/org/folio/invoices/utils/HelperUtils.java
+++ b/src/main/java/org/folio/invoices/utils/HelperUtils.java
@@ -60,6 +60,7 @@ import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 public class HelperUtils {
 
   public static final String INVOICE_ID = "invoiceId";
+  public static final String INVOICE = "invoice";
   public static final String LANG = "lang";
   public static final String OKAPI_URL = "X-Okapi-Url";
 
@@ -242,9 +243,9 @@ public class HelperUtils {
       .doubleValue();
   }
 
-  public static boolean isFieldsVerificationNeeded(Invoice existedInvoice) {
-    return existedInvoice.getStatus() == Invoice.Status.APPROVED || existedInvoice.getStatus() == Invoice.Status.PAID
-        || existedInvoice.getStatus() == Invoice.Status.CANCELLED;
+  public static boolean isPostApproval(Invoice invoice) {
+    return invoice.getStatus() == Invoice.Status.APPROVED || invoice.getStatus() == Invoice.Status.PAID
+        || invoice.getStatus() == Invoice.Status.CANCELLED;
   }
 
   public static Set<String> findChangedProtectedFields(Object newObject, Object existedObject, List<String> protectedFields) {
@@ -322,14 +323,16 @@ public class HelperUtils {
   }
 
   public static InvoiceLine calculateInvoiceLineTotals(InvoiceLine invoiceLine, Invoice invoice) {
-    String currency = invoice.getCurrency();
-    CurrencyUnit currencyUnit = Monetary.getCurrency(currency);
-    MonetaryAmount subTotal = Money.of(invoiceLine.getSubTotal(), currencyUnit);
+    if (!isPostApproval(invoice)) {
+      String currency = invoice.getCurrency();
+      CurrencyUnit currencyUnit = Monetary.getCurrency(currency);
+      MonetaryAmount subTotal = Money.of(invoiceLine.getSubTotal(), currencyUnit);
 
-    MonetaryAmount adjustmentTotals = calculateAdjustmentsTotal(invoiceLine.getAdjustments(), subTotal);
-    MonetaryAmount total = adjustmentTotals.add(subTotal);
-    invoiceLine.setAdjustmentsTotal(convertToDoubleWithRounding(adjustmentTotals));
-    invoiceLine.setTotal(convertToDoubleWithRounding(total));
+      MonetaryAmount adjustmentTotals = calculateAdjustmentsTotal(invoiceLine.getAdjustments(), subTotal);
+      MonetaryAmount total = adjustmentTotals.add(subTotal);
+      invoiceLine.setAdjustmentsTotal(convertToDoubleWithRounding(adjustmentTotals));
+      invoiceLine.setTotal(convertToDoubleWithRounding(total));
+    }
 
     return invoiceLine;
   }

--- a/src/main/java/org/folio/invoices/utils/HelperUtils.java
+++ b/src/main/java/org/folio/invoices/utils/HelperUtils.java
@@ -322,7 +322,7 @@ public class HelperUtils {
     return convertToDoubleWithRounding(convertedAmount);
   }
 
-  public static InvoiceLine calculateInvoiceLineTotals(InvoiceLine invoiceLine, Invoice invoice) {
+  public static void calculateInvoiceLineTotals(InvoiceLine invoiceLine, Invoice invoice) {
     if (!isPostApproval(invoice)) {
       String currency = invoice.getCurrency();
       CurrencyUnit currencyUnit = Monetary.getCurrency(currency);
@@ -333,8 +333,6 @@ public class HelperUtils {
       invoiceLine.setAdjustmentsTotal(convertToDoubleWithRounding(adjustmentTotals));
       invoiceLine.setTotal(convertToDoubleWithRounding(total));
     }
-
-    return invoiceLine;
   }
 
   public static Map<String, String> getOkapiHeaders(Message<JsonObject> message) {

--- a/src/main/java/org/folio/invoices/utils/InvoiceLineProtectedFields.java
+++ b/src/main/java/org/folio/invoices/utils/InvoiceLineProtectedFields.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 public enum InvoiceLineProtectedFields {
 
   ADJUSTMENTS("adjustments"),
+  ADJUSTMENTS_TOTAL("adjustmentsTotal"),
   FUND_DISTRIBUTIONS("fundDistributions"),
   INVOICE_ID("invoiceId"),
   INVOICE_LINE_NUMBER("invoiceLineNumber"),
@@ -16,7 +17,9 @@ public enum InvoiceLineProtectedFields {
   QUANTITY("quantity"),
   SUBSCRIPTION_INFO("subscriptionInfo"),
   SUBSCRIPTION_START("subscriptionStart"),
-  SUBSCRIPTION_END("subscriptionEnd");
+  SUBSCRIPTION_END("subscriptionEnd"),
+  SUB_TOTAL("subTotal"),
+  TOTAL("total");
 
 
   InvoiceLineProtectedFields(String field) {

--- a/src/main/java/org/folio/invoices/utils/InvoiceProtectedFields.java
+++ b/src/main/java/org/folio/invoices/utils/InvoiceProtectedFields.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 public enum InvoiceProtectedFields {
 
   ADJUSTMENTS("adjustments"),
+  ADJUSTMENTS_TOTAL("adjustmentsTotal"),
   APPROVED_BY("approvedBy"),
   APPROVAL_DATE("approvalDate"),
   CHK_SUBSCRIPTION_OVERLAP("chkSubscriptionOverlap"),
@@ -20,6 +21,8 @@ public enum InvoiceProtectedFields {
   VOUCHER_NUMBER("voucherNumber"),
   PAYMENT_ID("paymentId"),
   PO_NUMBERS("poNumbers"),
+  SUB_TOTAL("subTotal"),
+  TOTAL("total"),
   VENDOR_ID("vendorId");
 
   InvoiceProtectedFields(String field) {

--- a/src/main/java/org/folio/rest/impl/InvoiceLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/InvoiceLineHelper.java
@@ -109,7 +109,7 @@ public class InvoiceLineHelper extends AbstractHelper {
    * @param invoice invoice record
    * @return {code true} if any total value is different to original one
    */
-  private Boolean reCalculateInvoiceLineTotals(InvoiceLine invoiceLine, Invoice invoice) {
+  private boolean reCalculateInvoiceLineTotals(InvoiceLine invoiceLine, Invoice invoice) {
 
     // 1. Get original values
     Double existingTotal = invoiceLine.getTotal();
@@ -123,6 +123,19 @@ public class InvoiceLineHelper extends AbstractHelper {
     return !(Objects.equals(existingTotal, invoiceLine.getTotal())
         && Objects.equals(subTotal, invoiceLine.getSubTotal())
         && Objects.equals(adjustmentsTotal, invoiceLine.getAdjustmentsTotal()));
+  }
+
+  /**
+   * Compares totals of 2 invoice lines
+   *
+   * @param invoiceLine1 first invoice line
+   * @param invoiceLine2 second invoice line
+   * @return {code true} if any total value is different to original one
+   */
+  private boolean areTotalsEqual(InvoiceLine invoiceLine1, InvoiceLine invoiceLine2) {
+    return Objects.equals(invoiceLine1.getTotal(), invoiceLine2.getTotal())
+      && Objects.equals(invoiceLine1.getSubTotal(), invoiceLine2.getSubTotal())
+      && Objects.equals(invoiceLine1.getAdjustmentsTotal(), invoiceLine2.getAdjustmentsTotal());
   }
 
   /**
@@ -168,12 +181,12 @@ public class InvoiceLineHelper extends AbstractHelper {
         invoiceLine.setInvoiceLineNumber(invoiceLineFromStorage.getInvoiceLineNumber());
 
         // 4. Recalculate totals before update which also indicates if invoice requires update
-        Boolean isTotalOutOfSync = reCalculateInvoiceLineTotals(invoiceLineFromStorage, invoice);
+        calculateInvoiceLineTotals(invoiceLine, invoice);
 
         // 5. Update invoice line in storage
         return updateInvoiceLineToStorage(invoiceLine).thenRun(() -> {
           // 6. Trigger invoice update event only if this is required
-          if (isTotalOutOfSync) {
+          if (!areTotalsEqual(invoiceLine, invoiceLineFromStorage)) {
             updateInvoice(invoice);
           }
         });

--- a/src/main/java/org/folio/rest/impl/InvoiceLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/InvoiceLineHelper.java
@@ -1,7 +1,6 @@
 package org.folio.rest.impl;
 
 import static io.vertx.core.json.JsonObject.mapFrom;
-import static java.util.UUID.randomUUID;
 import static org.folio.invoices.utils.ErrorCodes.PROHIBITED_INVOICE_LINE_CREATION;
 import static org.folio.invoices.utils.HelperUtils.*;
 import static org.folio.invoices.utils.ResourcePathResolver.INVOICE_LINES;
@@ -150,7 +149,7 @@ public class InvoiceLineHelper extends AbstractHelper {
     // GET invoice-line from storage
     getInvoiceLine(id)
       .thenCompose(invoiceLineFromStorage -> getInvoice(invoiceLineFromStorage).thenApply(invoice -> {
-        Boolean isTotalOutOfSync = reCalculateInvoiceLineTotals(invoiceLineFromStorage, invoice);
+        boolean isTotalOutOfSync = reCalculateInvoiceLineTotals(invoiceLineFromStorage, invoice);
         if (isTotalOutOfSync) {
           updateOutOfSyncInvoiceLine(invoiceLineFromStorage, invoice);
         }
@@ -231,9 +230,6 @@ public class InvoiceLineHelper extends AbstractHelper {
    * @return completable future which might hold {@link InvoiceLine} on success or an exception if any issue happens
    */
   CompletableFuture<InvoiceLine> createInvoiceLine(InvoiceLine invoiceLine, Invoice invoice) {
-    invoiceLine.setId(randomUUID().toString());
-    invoiceLine.setInvoiceId(invoice.getId());
-
     return generateLineNumber(invoice).thenAccept(invoiceLine::setInvoiceLineNumber)
       .thenAccept(ok -> calculateInvoiceLineTotals(invoiceLine, invoice))
       .thenCompose(ok -> createRecordInStorage(mapFrom(invoiceLine), resourcesPath(INVOICE_LINES)))

--- a/src/test/java/org/folio/invoices/events/handlers/InvoiceSummaryTest.java
+++ b/src/test/java/org/folio/invoices/events/handlers/InvoiceSummaryTest.java
@@ -1,5 +1,6 @@
 package org.folio.invoices.events.handlers;
 
+import static org.folio.invoices.utils.HelperUtils.INVOICE;
 import static org.folio.invoices.utils.HelperUtils.INVOICE_ID;
 import static org.folio.invoices.utils.ResourcePathResolver.INVOICES;
 import static org.folio.rest.impl.InvoicesApiTest.OPEN_INVOICE_ID;
@@ -88,10 +89,9 @@ public class InvoiceSummaryTest extends ApiTestBase {
       .withSubTotal(10d)
       .withTotal(15d)
       .withCurrency("USD");
-    MockServer.addMockEntry(INVOICES, invoice);
 
-    sendEvent(createBody(VALID_UUID), context.asyncAssertSuccess(result -> {
-      assertThat(getInvoiceRetrievals(), hasSize(1));
+    sendEvent(createBody(invoice), context.asyncAssertSuccess(result -> {
+      assertThat(getInvoiceRetrievals(), empty());
       assertThat(getInvoiceLineSearches(), hasSize(1));
       assertThat(getInvoiceUpdates(), hasSize(1));
 
@@ -136,6 +136,10 @@ public class InvoiceSummaryTest extends ApiTestBase {
 
   private JsonObject createBody(String id) {
     return new JsonObject().put(INVOICE_ID, id);
+  }
+
+  private JsonObject createBody(Invoice invoice) {
+    return new JsonObject().put(INVOICE, JsonObject.mapFrom(invoice));
   }
 
   private void sendEvent(JsonObject data, Handler<AsyncResult<Message<String>>> replyHandler) {

--- a/src/test/java/org/folio/rest/impl/ApiTestBase.java
+++ b/src/test/java/org/folio/rest/impl/ApiTestBase.java
@@ -264,9 +264,11 @@ public class ApiTestBase {
   void verifyInvoiceSummaryUpdateEvent(int msgQty) {
     logger.debug("Verifying event bus messages");
     // Wait until event bus registers message
+
     await().atLeast(50, MILLISECONDS)
       .atMost(1, SECONDS)
       .until(() -> eventMessages, hasSize(msgQty));
+
     for (int i = 0; i < msgQty; i++) {
       Message<JsonObject> message = eventMessages.get(i);
       assertThat(message.address(), equalTo(MessageAddress.INVOICE_TOTALS.address));

--- a/src/test/java/org/folio/rest/impl/ApiTestBase.java
+++ b/src/test/java/org/folio/rest/impl/ApiTestBase.java
@@ -25,8 +25,8 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
@@ -83,7 +83,7 @@ public class ApiTestBase {
   private static boolean runningOnOwn;
 
   // The variable is defined in main thread but the value is going to be inserted in vert.x event loop thread
-  private static volatile List<Message<JsonObject>> eventMessages = new ArrayList<>();
+  private static List<Message<JsonObject>> eventMessages = new CopyOnWriteArrayList<>();
 
   /**
    * Define unit test specific beans to override actual ones
@@ -263,8 +263,8 @@ public class ApiTestBase {
 
   void verifyInvoiceSummaryUpdateEvent(int msgQty) {
     logger.debug("Verifying event bus messages");
-    // Wait until event bus registers message
 
+    // Wait until event bus registers message
     await().atLeast(50, MILLISECONDS)
       .atMost(1, SECONDS)
       .until(() -> eventMessages, hasSize(msgQty));

--- a/src/test/java/org/folio/rest/impl/ApiTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/ApiTestSuite.java
@@ -4,6 +4,8 @@ import io.restassured.RestAssured;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 import org.folio.invoices.events.handlers.InvoiceSummaryTest;
 import org.folio.rest.RestVerticle;
@@ -28,6 +30,7 @@ import java.util.concurrent.TimeoutException;
   InvoiceSummaryTest.class
 })
 public class ApiTestSuite {
+  private static final Logger logger = LoggerFactory.getLogger(ApiTestSuite.class);
 
   private static final int okapiPort = NetworkUtils.nextFreePort();
   static final int mockPort = NetworkUtils.nextFreePort();
@@ -37,6 +40,8 @@ public class ApiTestSuite {
 
   @BeforeClass
   public static void before() throws InterruptedException, ExecutionException, TimeoutException {
+    logger.info("=== Initializing mock server - START ===");
+
     if (vertx == null) {
       vertx = Vertx.vertx();
     }
@@ -63,6 +68,8 @@ public class ApiTestSuite {
     });
     deploymentComplete.get(60, TimeUnit.SECONDS);
     initialised = true;
+
+    logger.info("=== Initializing mock server - END ===");
   }
 
   @AfterClass

--- a/src/test/java/org/folio/rest/impl/InvoiceLinesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoiceLinesApiTest.java
@@ -179,6 +179,7 @@ public class InvoiceLinesApiTest extends ApiTestBase {
 
   @Test
   public void deleteInvoiceLinesBadLanguageTest() {
+    logger.info("=== Test to verify bad request error due to incorrect lang parameter value ===");
     String endpoint = String.format(INVOICE_LINE_ID_PATH, VALID_UUID) + String.format("?%s=%s", LANG_PARAM, INVALID_LANG) ;
 
     verifyDeleteResponse(endpoint, TEXT_PLAIN, 400);
@@ -528,12 +529,14 @@ public class InvoiceLinesApiTest extends ApiTestBase {
     verifyPut(String.format(INVOICE_LINE_ID_PATH, invoiceLine.getId()), JsonObject.mapFrom(invoiceLine).encode(), "", HttpStatus.SC_NO_CONTENT);
 
     verifyInvoiceSummaryUpdateEvent(0);
+    clearServiceInteractions();
 
     // Invoice line updated (invoice status = OPEN) - protected field not modified
     invoiceLine.setId(INVOICE_LINE_WITH_OPEN_EXISTED_INVOICE_ID);
     verifyPut(String.format(INVOICE_LINE_ID_PATH, invoiceLine.getId()), JsonObject.mapFrom(invoiceLine).encode(), "", HttpStatus.SC_NO_CONTENT);
 
     verifyInvoiceSummaryUpdateEvent(0);
+    clearServiceInteractions();
 
     // Invoice line updated (invoice status = APPROVED) - all protected fields modified
 
@@ -582,6 +585,7 @@ public class InvoiceLinesApiTest extends ApiTestBase {
     MatcherAssert.assertThat(expected, Matchers.arrayContainingInAnyOrder(failedFieldNames));
 
     verifyInvoiceSummaryUpdateEvent(0);
+    clearServiceInteractions();
   }
 
   private void verifyInvoiceLineUpdateCalls(int msgQty) {

--- a/src/test/java/org/folio/rest/impl/InvoiceLinesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoiceLinesApiTest.java
@@ -17,13 +17,11 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.util.*;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.folio.invoices.utils.ErrorCodes.PROHIBITED_INVOICE_LINE_CREATION;
-import static org.folio.invoices.utils.ResourcePathResolver.INVOICES;
 import static org.folio.invoices.utils.ResourcePathResolver.INVOICE_LINES;
 import static org.folio.invoices.utils.ResourcePathResolver.INVOICE_LINE_NUMBER;
 import static org.folio.rest.impl.AbstractHelper.ID;
@@ -34,7 +32,9 @@ import static org.folio.rest.impl.InvoicesApiTest.REVIEWED_INVOICE_ID;
 import static org.folio.rest.impl.InvoicesImpl.PROTECTED_AND_MODIFIED_FIELDS;
 import static org.folio.rest.impl.MockServer.INVOICE_LINE_NUMBER_ERROR_X_OKAPI_TENANT;
 import static org.folio.rest.impl.MockServer.addMockEntry;
-import static org.folio.rest.impl.MockServer.serverRqRs;
+import static org.folio.rest.impl.MockServer.getInvoiceLineRetrievals;
+import static org.folio.rest.impl.MockServer.getInvoiceLineUpdates;
+import static org.folio.rest.impl.MockServer.getInvoiceRetrievals;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.hamcrest.Matchers.notNullValue;
@@ -64,6 +64,8 @@ public class InvoiceLinesApiTest extends ApiTestBase {
   private static final String INVOICE_LINE_WITH_APPROVED_EXISTED_INVOICE_ID = "e0d08448-343b-118a-8c2f-4fb50248d672";
   private static final String INVOICE_LINE_WITH_OPEN_EXISTED_INVOICE_ID = "5cb6d270-a54c-4c38-b645-3ae7f249c606";
   private static final String INVOICE_LINE_WITH_INTERNAL_ERROR_ON_GET_INVOICE = "4051b42d-c6cf-4306-a331-209514af9877";
+  private static final String INVOICE_LINE_OUTDATED_TOTAL = "55e4b6f5-f974-42da-9a77-24d4e8ef0e70";
+  private static final String INVOICE_LINE_OUTDATED_TOTAL_PATH = INVOICE_LINES_MOCK_DATA_PATH + INVOICE_LINE_OUTDATED_TOTAL + ".json";
   static final String INVOICE_LINE_WITH_APPROVED_INVOICE_SAMPLE_PATH = INVOICE_LINES_MOCK_DATA_PATH + INVOICE_LINE_WITH_APPROVED_EXISTED_INVOICE_ID + ".json";
 
 
@@ -92,64 +94,60 @@ public class InvoiceLinesApiTest extends ApiTestBase {
   }
 
   @Test
-  public void getInvoicingInvoiceLinesByIdTest() throws Exception {
+  public void getInvoicingInvoiceLinesByIdTest() {
     logger.info("=== Test Get Invoice line By Id ===");
 
-    JsonObject invoiceLinesList = new JsonObject(getMockData(INVOICE_LINES_LIST_PATH));
-    String id = invoiceLinesList.getJsonArray("invoiceLines").getJsonObject(0).getString(ID);
-    logger.info(String.format("using mock datafile: %s%s.json", INVOICE_LINES_LIST_PATH, id));
-
-    final InvoiceLine resp = verifySuccessGet(INVOICE_LINES_PATH + "/" + id, InvoiceLine.class);
+    final InvoiceLine resp = verifySuccessGet(String.format(INVOICE_LINE_ID_PATH, INVOICE_LINE_WITH_OPEN_EXISTED_INVOICE_ID),
+        InvoiceLine.class);
 
     logger.info(JsonObject.mapFrom(resp).encodePrettily());
-    assertEquals(id, resp.getId());
 
     // MODINVOICE-86 calculate the totals and if different from what was retrieved, write it back to storage
-    Double existingTotal = invoiceLinesList.getJsonArray("invoiceLines")
-      .getJsonObject(0)
-      .getDouble("total");
-    assertThat(existingTotal, equalTo(2.00d)); // outdated total in storage
-    double expectedTotal = 2.42d;
-    
-    final InvoiceLine updatedResponse = verifySuccessGet(INVOICE_LINES_PATH + "/" + id, InvoiceLine.class);
-
-    assertThat(updatedResponse.getTotal(), equalTo(expectedTotal)); // updated total after recalculating
+    assertThat(getInvoiceLineUpdates(), empty());
+    verifyInvoiceSummaryUpdateEvent(0);
   }
 
   @Test
-  public void getInvoicingInvoiceLinesByIdCalculateTotalExceptionTest() throws Exception {
-    logger.info("=== Test error calculating invoice line while doing get Invoice line By Id ===");
-
-    JsonObject invoiceLinesList = new JsonObject(getMockData(INVOICE_LINES_LIST_PATH));
-    String id = invoiceLinesList.getJsonArray("invoiceLines")
-      .getJsonObject(1)
-      .getString(ID);
-    logger.info(String.format("using mock datafile: %s%s.json", INVOICE_LINES_LIST_PATH, id));
-
-    verifyGet(INVOICE_LINES_PATH + "/" + id, APPLICATION_JSON, 404);
-  }
-
-  @Test
-  public void testGetInvoicingInvoiceLinesByIdUpdateTotalException() throws Exception {
+  public void testGetInvoicingInvoiceLinesByIdUpdateTotal() {
     logger.info("=== Test 200 when correct calculated invoice line total is returned without waiting to update in storage ===");
 
-    final Response resp = verifyGet(INVOICE_LINES_PATH + "/" + CALCULATE_INVOICE_LINE_TOTAL, APPLICATION_JSON, 200);
+    final InvoiceLine resp = verifySuccessGet(INVOICE_LINES_PATH + "/" + INVOICE_LINE_OUTDATED_TOTAL, InvoiceLine.class);
 
-    resp.getBody().as(InvoiceLine.class).getTotal();
     Double expectedTotal = 4.62;
-    assertThat(resp.getBody().as(InvoiceLine.class).getTotal(), equalTo(expectedTotal));
+    assertThat(resp.getTotal(), equalTo(expectedTotal));
+
+    // MODINVOICE-86 Check that invoice line update called which also triggered invoice update
+    assertThat(getInvoiceLineUpdates(), hasSize(1));
+    verifyInvoiceSummaryUpdateEvent(1);
   }
 
   @Test
-  public void getInvoicingInvoiceLinesByIdNotFoundTest() throws MalformedURLException {
+  public void testGetInvoicingInvoiceLinesByIdUpdateTotalException() {
+    logger.info("=== Test 200 when correct calculated invoice line total is returned without waiting to update in storage ===");
+
+    InvoiceLine invoiceLine = getMockAsJson(INVOICE_LINE_OUTDATED_TOTAL_PATH).mapTo(InvoiceLine.class);
+    addMockEntry(INVOICE_LINES, invoiceLine.withId(ID_FOR_INTERNAL_SERVER_ERROR_PUT));
+
+    final Response resp = verifyGet(INVOICE_LINES_PATH + "/" + invoiceLine.getId(), APPLICATION_JSON, 200);
+
+    Double expectedTotal = 4.62;
+    assertThat(resp.getBody().as(InvoiceLine.class).getTotal(), equalTo(expectedTotal));
+
+    // Check that invoice line update called which is expected to fail so invoice update is not triggered
+    assertThat(getInvoiceLineUpdates(), hasSize(1));
+    verifyInvoiceSummaryUpdateEvent(0);
+  }
+
+  @Test
+  public void getInvoicingInvoiceLinesByIdNotFoundTest() {
     logger.info("=== Test Get Invoice line by Id - 404 Not found ===");
 
-    final Response resp = verifyGet(INVOICE_LINES_PATH + "/" + BAD_INVOICE_LINE_ID, APPLICATION_JSON, 404);
+    final Response resp = verifyGet(INVOICE_LINES_PATH + "/" + ID_DOES_NOT_EXIST, APPLICATION_JSON, 404);
 
     String actual = resp.getBody().as(Errors.class).getErrors().get(0).getMessage();
     logger.info("Id not found: " + actual);
 
-    assertEquals(BAD_INVOICE_LINE_ID, actual);
+    assertEquals(ID_DOES_NOT_EXIST, actual);
   }
 
   @Test
@@ -158,6 +156,7 @@ public class InvoiceLinesApiTest extends ApiTestBase {
 
     addMockEntry(INVOICE_LINES, JsonObject.mapFrom(new InvoiceLine().withId(VALID_UUID).withInvoiceId(VALID_UUID)));
     verifyDeleteResponse(String.format(INVOICE_LINE_ID_PATH, VALID_UUID), "", 204);
+    verifyInvoiceSummaryUpdateEvent(1);
   }
 
   @Test
@@ -256,7 +255,8 @@ public class InvoiceLinesApiTest extends ApiTestBase {
 
     verifyPut(String.format(INVOICE_LINE_ID_PATH, INVOICE_LINE_WITH_APPROVED_EXISTED_INVOICE_ID), reqData, "", 204);
 
-    verifyInvoiceSummaryUpdateEvent(1);
+    // No any total changed
+    verifyInvoiceSummaryUpdateEvent(0);
   }
 
   @Test
@@ -421,7 +421,7 @@ public class InvoiceLinesApiTest extends ApiTestBase {
   }
 
   @Test
-  public void testPostInvoicingInvoiceLinesWithRelationshipTotal() throws Exception {
+  public void testPostInvoicingInvoiceLinesWithRelationshipTotal() {
     logger.info("=== Test Post Invoice Lines to use only In addition To RelationToTotal ===");
 
 
@@ -473,14 +473,16 @@ public class InvoiceLinesApiTest extends ApiTestBase {
   }
 
   private void checkNumberOfRequests(String invoiceLineId) {
-      InvoiceLine invoiceLine = getMockAsJson(INVOICE_LINE_WITH_APPROVED_INVOICE_SAMPLE_PATH).mapTo(InvoiceLine.class);
-      invoiceLine.setId(invoiceLineId);
-      verifyPut(String.format(INVOICE_LINE_ID_PATH, invoiceLineId), JsonObject.mapFrom(invoiceLine).encode(), "", HttpStatus.SC_NO_CONTENT);
-      MatcherAssert.assertThat(serverRqRs.row(INVOICE_LINES).get(HttpMethod.GET), hasSize(1));
-      MatcherAssert.assertThat(serverRqRs.row(INVOICES).get(HttpMethod.GET), hasSize(1));
-      MatcherAssert.assertThat(serverRqRs.row(INVOICE_LINES).get(HttpMethod.PUT), hasSize(1));
+    InvoiceLine invoiceLine = getMockAsJson(INVOICE_LINE_WITH_APPROVED_INVOICE_SAMPLE_PATH).mapTo(InvoiceLine.class);
+    invoiceLine.setId(invoiceLineId);
+    verifyPut(String.format(INVOICE_LINE_ID_PATH, invoiceLineId), JsonObject.mapFrom(invoiceLine).encode(), "", HttpStatus.SC_NO_CONTENT);
 
-    verifyInvoiceSummaryUpdateEvent(1);
+    MatcherAssert.assertThat(getInvoiceLineRetrievals(), hasSize(1));
+    MatcherAssert.assertThat(getInvoiceRetrievals(), hasSize(1));
+    MatcherAssert.assertThat(getInvoiceLineUpdates(), hasSize(1));
+
+    // All totals are unchanged
+    verifyInvoiceSummaryUpdateEvent(0);
     clearServiceInteractions();
   }
 
@@ -490,18 +492,15 @@ public class InvoiceLinesApiTest extends ApiTestBase {
     InvoiceLine invoiceLine = getMockAsJson(INVOICE_LINE_WITH_APPROVED_INVOICE_SAMPLE_PATH).mapTo(InvoiceLine.class);
 
     // Invoice line updated (invoice status = APPROVED) - protected field not modified
-    invoiceLine.setId(INVOICE_LINE_WITH_APPROVED_EXISTED_INVOICE_ID);
     verifyPut(String.format(INVOICE_LINE_ID_PATH, invoiceLine.getId()), JsonObject.mapFrom(invoiceLine).encode(), "", HttpStatus.SC_NO_CONTENT);
 
-    verifyInvoiceSummaryUpdateEvent(1);
-    clearServiceInteractions();
+    verifyInvoiceSummaryUpdateEvent(0);
 
     // Invoice line updated (invoice status = OPEN) - protected field not modified
     invoiceLine.setId(INVOICE_LINE_WITH_OPEN_EXISTED_INVOICE_ID);
     verifyPut(String.format(INVOICE_LINE_ID_PATH, invoiceLine.getId()), JsonObject.mapFrom(invoiceLine).encode(), "", HttpStatus.SC_NO_CONTENT);
 
-    verifyInvoiceSummaryUpdateEvent(1);
-    clearServiceInteractions();
+    verifyInvoiceSummaryUpdateEvent(0);
 
     // Invoice line updated (invoice status = APPROVED) - all protected fields modified
 

--- a/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
@@ -41,6 +41,7 @@ import static org.folio.rest.impl.MockServer.INVOICE_NUMBER_ERROR_X_OKAPI_TENANT
 import static org.folio.rest.impl.MockServer.NON_EXIST_CONFIG_X_OKAPI_TENANT;
 import static org.folio.rest.impl.MockServer.TEST_PREFIX;
 import static org.folio.rest.impl.MockServer.addMockEntry;
+import static org.folio.rest.impl.MockServer.getInvoiceCreations;
 import static org.folio.rest.impl.MockServer.getInvoiceLineSearches;
 import static org.folio.rest.impl.MockServer.getInvoiceRetrievals;
 import static org.folio.rest.impl.MockServer.getInvoiceSearches;
@@ -1162,8 +1163,7 @@ public class InvoicesApiTest extends ApiTestBase {
     assertThat(MockServer.serverRqRs.get(FOLIO_INVOICE_NUMBER, HttpMethod.GET), hasSize(1));
 
     // Check that invoice in the response and the one in storage are the same
-    Invoice invoiceToStorage = getRqRsEntries(HttpMethod.POST, INVOICES).get(0).mapTo(Invoice.class);
-    assertThat(respData, equalTo(invoiceToStorage));
+    compareRecordWithSentToStorage(respData);
   }
 
   @Test
@@ -1187,11 +1187,8 @@ public class InvoicesApiTest extends ApiTestBase {
     // Verify that expected number of external calls made
     assertThat(serverRqRs.cellSet(), hasSize(2));
     assertThat(getRqRsEntries(HttpMethod.GET, FOLIO_INVOICE_NUMBER), hasSize(1));
-    assertThat(getRqRsEntries(HttpMethod.POST, INVOICES), hasSize(1));
 
-    // Check that invoice in the response and the one in storage are the same
-    Invoice invoiceToStorage = getRqRsEntries(HttpMethod.POST, INVOICES).get(0).mapTo(Invoice.class);
-    assertThat(resp, equalTo(invoiceToStorage));
+    compareRecordWithSentToStorage(resp);
   }
 
   @Test
@@ -1216,11 +1213,8 @@ public class InvoicesApiTest extends ApiTestBase {
     // Verify that expected number of external calls made
     assertThat(serverRqRs.cellSet(), hasSize(2));
     assertThat(getRqRsEntries(HttpMethod.GET, FOLIO_INVOICE_NUMBER), hasSize(1));
-    assertThat(getRqRsEntries(HttpMethod.POST, INVOICES), hasSize(1));
 
-    // Check that invoice in the response and the one in storage are the same
-    Invoice invoiceToStorage = getRqRsEntries(HttpMethod.POST, INVOICES).get(0).mapTo(Invoice.class);
-    assertThat(resp, equalTo(invoiceToStorage));
+    compareRecordWithSentToStorage(resp);
   }
 
   @Test
@@ -1244,11 +1238,8 @@ public class InvoicesApiTest extends ApiTestBase {
     // Verify that expected number of external calls made
     assertThat(serverRqRs.cellSet(), hasSize(2));
     assertThat(getRqRsEntries(HttpMethod.GET, FOLIO_INVOICE_NUMBER), hasSize(1));
-    assertThat(getRqRsEntries(HttpMethod.POST, INVOICES), hasSize(1));
 
-    // Check that invoice in the response and the one in storage are the same
-    Invoice invoiceToStorage = getRqRsEntries(HttpMethod.POST, INVOICES).get(0).mapTo(Invoice.class);
-    assertThat(resp, equalTo(invoiceToStorage));
+    compareRecordWithSentToStorage(resp);
   }
 
   @Test
@@ -1493,5 +1484,12 @@ public class InvoicesApiTest extends ApiTestBase {
     await().atLeast(50, MILLISECONDS)
       .atMost(1, SECONDS)
       .until(MockServer::getInvoiceUpdates, hasSize(msgQty));
+  }
+
+  private void compareRecordWithSentToStorage(Invoice invoice) {
+    // Verify that invoice sent to storage is the same as in response
+    assertThat(getInvoiceCreations(), hasSize(1));
+    Invoice invoiceToStorage = getInvoiceCreations().get(0).mapTo(Invoice.class);
+    assertThat(invoice, equalTo(invoiceToStorage));
   }
 }

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -189,6 +189,10 @@ public class MockServer {
     return getRqRsEntries(HttpMethod.PUT, INVOICES);
   }
 
+  public static List<JsonObject> getInvoiceCreations() {
+    return getRqRsEntries(HttpMethod.POST, INVOICES);
+  }
+
   public static List<JsonObject> getInvoiceLineSearches() {
     return getCollectionRecords(getRqRsEntries(HttpMethod.GET, INVOICE_LINES));
   }
@@ -199,6 +203,10 @@ public class MockServer {
 
   public static List<JsonObject> getInvoiceLineUpdates() {
     return getRqRsEntries(HttpMethod.PUT, INVOICE_LINES);
+  }
+
+  public static List<JsonObject> getInvoiceLineCreations() {
+    return getRqRsEntries(HttpMethod.POST, INVOICE_LINES);
   }
 
   private static List<JsonObject> getCollectionRecords(List<JsonObject> entries) {

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -182,9 +182,7 @@ public class MockServer {
   }
 
   public static List<JsonObject> getInvoiceRetrievals() {
-    return getRqRsEntries(HttpMethod.GET, INVOICES).stream()
-      .filter(json -> json.containsKey(ID))
-      .collect(toList());
+    return getRecordsByIds(getRqRsEntries(HttpMethod.GET, INVOICES));
   }
 
   public static List<JsonObject> getInvoiceUpdates() {
@@ -195,8 +193,20 @@ public class MockServer {
     return getCollectionRecords(getRqRsEntries(HttpMethod.GET, INVOICE_LINES));
   }
 
+  public static List<JsonObject> getInvoiceLineRetrievals() {
+    return getRecordsByIds(getRqRsEntries(HttpMethod.GET, INVOICE_LINES));
+  }
+
+  public static List<JsonObject> getInvoiceLineUpdates() {
+    return getRqRsEntries(HttpMethod.PUT, INVOICE_LINES);
+  }
+
   private static List<JsonObject> getCollectionRecords(List<JsonObject> entries) {
     return entries.stream().filter(json -> !json.containsKey(ID)).collect(toList());
+  }
+
+  private static List<JsonObject> getRecordsByIds(List<JsonObject> entries) {
+    return entries.stream().filter(json -> json.containsKey(ID)).collect(toList());
   }
 
   private Router defineRoutes() {

--- a/src/test/resources/mockdata/invoiceLines/55e4b6f5-f974-42da-9a77-24d4e8ef0e70.json
+++ b/src/test/resources/mockdata/invoiceLines/55e4b6f5-f974-42da-9a77-24d4e8ef0e70.json
@@ -14,7 +14,7 @@
   "subscriptionInfo": "Subscription information",
   "subscriptionStart": "2018-08-01T00:00:00.000+0000",
   "subscriptionEnd": "2019-01-01T00:00:00.000+0000",
-  "invoiceId": "c0d08448-347b-418a-8c2f-5fb50248d67e",
+  "invoiceId": "52fd6ec7-ddc3-4c53-bc26-2779afc27136",
   "fundDistributions": [
     {
       "code": "EUHIST",


### PR DESCRIPTION
## Purpose
[MODINVOICE-87](https://issues.folio.org/browse/MODINVOICE-87) Calculate and persist invoice totals
[MODINVOICE-86](https://issues.folio.org/browse/MODINVOICE-86) Calculate and persist invoice line totals on creation

## Approach
[MODINVOICE-87](https://issues.folio.org/browse/MODINVOICE-87):
- Trigger calculations only if invoice is still open for modifications i.e. status is `OPEN` or `REVIEWED`
- When invoice line is retrieved and totals are outdated, the record is persisted in storage and on success triggers an event to update invoice
- Adding `adjustmentsTotal`, `subTotal` and `total` as protected i.e. cannot be modified anymore after invoice approval

[MODINVOICE-86](https://issues.folio.org/browse/MODINVOICE-86):
- Updating logic to store invoice line totals in storage
- Adding unit tests to check that `POST` invoice line record in response is the same as one sent to storage

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
