### PR TITLE
MODINVOICE-89: Disallow "deleted" acq units from being assigned to invoices

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <jsonschema_paths>acq-models/mod-invoice-storage/schemas,raml-util/schemas,acq-models/common/schemas/</jsonschema_paths>
-    <raml-module-builder.version>26.4.0</raml-module-builder.version>
+    <raml-module-builder.version>27.0.0</raml-module-builder.version>
     <vertx.version>3.5.4</vertx.version>
     <junit.version>4.12</junit.version>
     <rest-assured.version>3.1.1</rest-assured.version>

--- a/src/main/java/org/folio/invoices/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/invoices/utils/ErrorCodes.java
@@ -23,7 +23,7 @@ public enum ErrorCodes {
   MISMATCH_BETWEEN_ID_IN_PATH_AND_BODY("idMismatch", "Mismatch between id in path and request body"),
   USER_HAS_NO_PERMISSIONS("userHasNoPermission", "User does not have permissions - operation is restricted"),
   USER_HAS_NO_ACQ_PERMISSIONS("userHasNoAcqUnitsPermission", "User does not have permissions to manage acquisition units assignments - operation is restricted"),
-  ACQ_UNITS_NOT_FOUND("acqUnitsNotFound", "Acquisitions units assigned to invoice not found");
+  ACQ_UNITS_NOT_FOUND("acqUnitsNotFound", "Acquisitions units assigned to the record not found");
 
   private final String code;
   private final String description;

--- a/src/main/java/org/folio/invoices/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/invoices/utils/ErrorCodes.java
@@ -23,7 +23,7 @@ public enum ErrorCodes {
   MISMATCH_BETWEEN_ID_IN_PATH_AND_BODY("idMismatch", "Mismatch between id in path and request body"),
   USER_HAS_NO_PERMISSIONS("userHasNoPermission", "User does not have permissions - operation is restricted"),
   USER_HAS_NO_ACQ_PERMISSIONS("userHasNoAcqUnitsPermission", "User does not have permissions to manage acquisition units assignments - operation is restricted"),
-  ACQ_UNITS_NOT_FOUND("acqUnitsNotFound", "Acquisition units not found");
+  ACQ_UNITS_NOT_FOUND("acqUnitsNotFound", "Acquisitions units assigned to invoice not found");
 
   private final String code;
   private final String description;

--- a/src/main/java/org/folio/invoices/utils/HelperUtils.java
+++ b/src/main/java/org/folio/invoices/utils/HelperUtils.java
@@ -76,7 +76,9 @@ public class HelperUtils {
   public static final String OKAPI_URL = "X-Okapi-Url";
   public static final String QUERY_PARAM_START_WITH = "invoice_lines.id==";
   public static final String SEARCH_PARAMS = "?limit=%s&offset=%s%s&lang=%s";
-
+  public static final String IS_DELETED_PROP = "isDeleted";
+  public static final String ALL_UNITS_CQL = IS_DELETED_PROP + "=*";
+  
   private static final String EXCEPTION_CALLING_ENDPOINT_MSG = "Exception calling {} {}";
   private static final String CALLING_ENDPOINT_MSG = "Sending {} {}";
   private static final Pattern CQL_SORT_BY_PATTERN = Pattern.compile("(.*)(\\ssortBy\\s.*)", Pattern.CASE_INSENSITIVE);

--- a/src/main/java/org/folio/rest/impl/ProtectionHelper.java
+++ b/src/main/java/org/folio/rest/impl/ProtectionHelper.java
@@ -111,7 +111,7 @@ public class ProtectionHelper extends AbstractHelper {
   }
   
   /**
-   * Check whether the user is a member of at least one group from which the related order belongs.
+   * Check whether the user is a member of at least one group from which the related invoice belongs.
    *
    * @return list of unit ids associated with user.
    */

--- a/src/main/java/org/folio/rest/impl/ProtectionHelper.java
+++ b/src/main/java/org/folio/rest/impl/ProtectionHelper.java
@@ -9,6 +9,7 @@ import static org.folio.invoices.utils.ResourcePathResolver.ACQUISITIONS_MEMBERS
 import static org.folio.invoices.utils.ResourcePathResolver.ACQUISITIONS_UNITS;
 import static org.folio.invoices.utils.ResourcePathResolver.resourcesPath;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -17,6 +18,7 @@ import java.util.stream.Collectors;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 import one.util.streamex.StreamEx;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.folio.HttpStatus;
 import org.folio.invoices.rest.exceptions.HttpException;
 import org.folio.invoices.utils.HelperUtils;
@@ -26,7 +28,6 @@ import org.folio.rest.acq.model.units.AcquisitionsUnitCollection;
 import org.folio.rest.acq.model.units.AcquisitionsUnitMembership;
 import org.folio.rest.acq.model.units.AcquisitionsUnitMembershipCollection;
 import org.folio.rest.jaxrs.model.Error;
-import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 
 import io.vertx.core.Context;
@@ -39,37 +40,76 @@ public class ProtectionHelper extends AbstractHelper {
   static final String GET_UNITS_BY_QUERY = resourcesPath(ACQUISITIONS_UNITS) + SEARCH_PARAMS;
   static final String GET_UNITS_MEMBERSHIPS_BY_QUERY = resourcesPath(ACQUISITIONS_MEMBERSHIPS) + SEARCH_PARAMS;
 
+  private List<AcquisitionsUnit> fetchedUnits = new ArrayList<>();
+
   public ProtectionHelper(HttpClientInterface httpClient, Map<String, String> okapiHeaders, Context ctx, String lang) {
     super(httpClient, okapiHeaders, ctx, lang);
 }
 
   /**
-   * This method determines status of operation restriction based on unit IDs.
-   * @param unitIds list of unit IDs.
+   * This method determines status of operation restriction based on unit IDs from {@link Invoice}.
    *
-   * @throws HttpException if user hasn't permissions or units not found
+   * @param unitIds   list of unit IDs.
+   * @param operation type of operation
+   * @return completable future completed exceptionally if user does not have rights to perform operation or any unit does not
+   *         exist; successfully otherwise
    */
   public CompletableFuture<Void> isOperationRestricted(List<String> unitIds, ProtectedOperationType operation) {
     if (CollectionUtils.isNotEmpty(unitIds)) {
-      return getUnitsByIds(unitIds)
-        .thenCompose(units -> {
-          if (unitIds.size() == units.size()) {
-            if (Boolean.TRUE.equals(applyMergingStrategy(units, operation))) {
-              return verifyUserIsMemberOfAcqUnits(unitIds);
-            }
-            return CompletableFuture.completedFuture(null);
-          } else {
-            Error error = ACQ_UNITS_NOT_FOUND.toError();
-            unitIds.removeAll(units.stream().map(AcquisitionsUnit::getId).collect(Collectors.toSet()));
-            error.getParameters().add(new Parameter().withKey(ACQUISITIONS_UNIT_IDS).withValue(unitIds.toString()));
-            throw new HttpException(HttpStatus.HTTP_VALIDATION_ERROR.toInt(), error);
+      return getUnitsByIds(unitIds).thenCompose(units -> {
+        if (unitIds.size() == units.size()) {
+          // In case any unit is "soft deleted", just skip it (refer to MODINVOICE-89)
+          List<AcquisitionsUnit> activeUnits = units.stream()
+            .filter(unit -> !unit.getIsDeleted())
+            .collect(Collectors.toList());
+
+          if (!activeUnits.isEmpty() && Boolean.TRUE.equals(applyMergingStrategy(activeUnits, operation))) {
+            return verifyUserIsMemberOfAcqUnits(extractUnitIds(activeUnits));
           }
-        });
+          return CompletableFuture.completedFuture(null);
+        } else {
+          // In case any unit "hard deleted" or never existed by specified uuid
+          throw new HttpException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt(),
+              buildUnitsNotFoundError(unitIds, extractUnitIds(units)));
+        }
+      });
     } else {
       return CompletableFuture.completedFuture(null);
     }
   }
 
+  private List<String> extractUnitIds(List<AcquisitionsUnit> activeUnits) {
+    return activeUnits.stream().map(AcquisitionsUnit::getId).collect(Collectors.toList());
+  }
+
+  /**
+   * Verifies if all acquisition units exist and active based on passed ids
+   *
+   * @param acqUnitIds list of unit IDs.
+   * @return completable future completed successfully if all units exist and active or exceptionally otherwise
+   */
+  public CompletableFuture<Void> verifyIfUnitsAreActive(List<String> acqUnitIds) {
+    if (acqUnitIds.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    return getUnitsByIds(acqUnitIds).thenAccept(units -> {
+      List<String> activeUnitIds = units.stream()
+        .filter(unit -> !unit.getIsDeleted())
+        .map(AcquisitionsUnit::getId)
+        .collect(Collectors.toList());
+
+      if (acqUnitIds.size() != activeUnitIds.size()) {
+        throw new HttpException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt(), buildUnitsNotFoundError(acqUnitIds, activeUnitIds));
+      }
+    });
+  }
+
+  private Error buildUnitsNotFoundError(List<String> expectedUnitIds, List<String> availableUnitIds) {
+    List<String> missingUnitIds = ListUtils.subtract(expectedUnitIds, availableUnitIds);
+    return ACQ_UNITS_NOT_FOUND.toError().withAdditionalProperty(ACQUISITIONS_UNIT_IDS, missingUnitIds);
+  }
+  
   /**
    * Check whether the user is a member of at least one group from which the related order belongs.
    *
@@ -88,14 +128,28 @@ public class ProtectionHelper extends AbstractHelper {
 
   /**
    * This method returns list of {@link AcquisitionsUnit} based on list of unit ids
+   * 
    * @param unitIds list of unit ids
    *
    * @return list of {@link AcquisitionsUnit}
    */
   private CompletableFuture<List<AcquisitionsUnit>> getUnitsByIds(List<String> unitIds) {
+    // Check if all required units are already available
+    List<AcquisitionsUnit> units = fetchedUnits.stream()
+      .filter(unit -> unitIds.contains(unit.getId()))
+      .distinct()
+      .collect(Collectors.toList());
+
+    if (units.size() == unitIds.size()) {
+      return CompletableFuture.completedFuture(units);
+    }
+
     String query = convertIdsToCqlQuery(unitIds);
-    return getAcquisitionsUnits(query, 0, Integer.MAX_VALUE)
-      .thenApply(AcquisitionsUnitCollection::getAcquisitionsUnits);
+    return getAcquisitionsUnits(query, 0, Integer.MAX_VALUE).thenApply(acquisitionsUnitCollection -> {
+      List<AcquisitionsUnit> acquisitionsUnits = acquisitionsUnitCollection.getAcquisitionsUnits();
+      fetchedUnits.addAll(acquisitionsUnits);
+      return acquisitionsUnits;
+    });
   }
 
   /**

--- a/src/main/java/org/folio/rest/impl/ProtectionHelper.java
+++ b/src/main/java/org/folio/rest/impl/ProtectionHelper.java
@@ -5,6 +5,7 @@ import static org.folio.invoices.utils.ErrorCodes.USER_HAS_NO_PERMISSIONS;
 import static org.folio.invoices.utils.HelperUtils.convertIdsToCqlQuery;
 import static org.folio.invoices.utils.HelperUtils.getEndpointWithQuery;
 import static org.folio.invoices.utils.HelperUtils.handleGetRequest;
+import static org.folio.invoices.utils.HelperUtils.ALL_UNITS_CQL;
 import static org.folio.invoices.utils.ResourcePathResolver.ACQUISITIONS_MEMBERSHIPS;
 import static org.folio.invoices.utils.ResourcePathResolver.ACQUISITIONS_UNITS;
 import static org.folio.invoices.utils.ResourcePathResolver.resourcesPath;
@@ -144,7 +145,7 @@ public class ProtectionHelper extends AbstractHelper {
       return CompletableFuture.completedFuture(units);
     }
 
-    String query = convertIdsToCqlQuery(unitIds);
+    String query = ALL_UNITS_CQL + " and " + convertIdsToCqlQuery(unitIds);
     return getAcquisitionsUnits(query, 0, Integer.MAX_VALUE).thenApply(acquisitionsUnitCollection -> {
       List<AcquisitionsUnit> acquisitionsUnits = acquisitionsUnitCollection.getAcquisitionsUnits();
       fetchedUnits.addAll(acquisitionsUnits);

--- a/src/test/java/org/folio/rest/impl/ApiTestBase.java
+++ b/src/test/java/org/folio/rest/impl/ApiTestBase.java
@@ -132,8 +132,7 @@ public class ApiTestBase {
 
   protected void clearServiceInteractions() {
     eventMessages.clear();
-    MockServer.serverRqRs.clear();
-    MockServer.serverRqQueries.clear();
+    MockServer.release();
   }
 
   @AfterClass

--- a/src/test/java/org/folio/rest/impl/protection/InvoicesProtectionTest.java
+++ b/src/test/java/org/folio/rest/impl/protection/InvoicesProtectionTest.java
@@ -6,14 +6,26 @@ import static org.folio.invoices.utils.ErrorCodes.ACQ_UNITS_NOT_FOUND;
 import static org.folio.invoices.utils.ErrorCodes.USER_HAS_NO_ACQ_PERMISSIONS;
 import static org.folio.invoices.utils.ErrorCodes.USER_HAS_NO_PERMISSIONS;
 import static org.folio.rest.impl.InvoicesApiTest.INVOICE_PATH;
+import static org.folio.invoices.utils.ResourcePathResolver.ACQUISITIONS_UNITS;
 import static org.folio.rest.impl.ProtectionHelper.ACQUISITIONS_UNIT_IDS;
+import static org.folio.rest.impl.protection.ProtectedOperations.UPDATE;
+import static org.folio.rest.impl.MockServer.addMockEntry;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
 
+import java.util.Arrays;
 import java.util.Collections;
-
+import java.util.List;
 import org.folio.HttpStatus;
+import org.folio.rest.acq.model.units.AcquisitionsUnit;
+import org.folio.rest.acq.model.units.AcquisitionsUnitCollection;
+import org.folio.rest.impl.MockServer;
+import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Invoice;
 import org.junit.Test;
@@ -42,12 +54,11 @@ public class InvoicesProtectionTest extends ProtectedEntityTestBase {
 
     final Headers headers = prepareHeaders(X_OKAPI_TENANT, X_OKAPI_USER_ID, ALL_DESIRED_PERMISSIONS_HEADER);
     Errors errors = operation.process(INVOICE_PATH, encodePrettily(prepareInvoice(NON_EXISTENT_UNITS)),
-      headers, APPLICATION_JSON, HttpStatus.HTTP_VALIDATION_ERROR.toInt()).as(Errors.class);
+      headers, APPLICATION_JSON, HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()).as(Errors.class);
 
     assertThat(errors.getErrors(), hasSize(1));
     assertThat(errors.getErrors().get(0).getCode(), equalTo(ACQ_UNITS_NOT_FOUND.getCode()));
-    assertThat(errors.getErrors().get(0).getParameters(), hasSize(1));
-    assertThat(errors.getErrors().get(0).getParameters().get(0).getKey(), equalTo(ACQUISITIONS_UNIT_IDS));
+
     // Verify number of sub-requests
     validateNumberOfRequests(1, 0);
   }
@@ -125,5 +136,127 @@ public class InvoicesProtectionTest extends ProtectedEntityTestBase {
     assertThat(errors.getErrors().get(0).getCode(), equalTo(USER_HAS_NO_ACQ_PERMISSIONS.getCode()));
 
     validateNumberOfRequests(0, 0);
+  }
+  
+  @Test
+  @Parameters({
+    "CREATE",
+    "UPDATE"
+  })
+  public void testAssigningSoftDeletedUnit(ProtectedOperations operation) {
+    logger.info("=== Test invoice contains \"soft deleted\" unit id - expecting of call only to Units API ===");
+    
+    final Headers headers = prepareHeaders(X_OKAPI_TENANT, ALL_DESIRED_PERMISSIONS_HEADER, X_OKAPI_USER_ID);
+
+    // Acq to order in storage for update case and
+    AcquisitionsUnit unit1 = prepareTestUnit(false);
+    AcquisitionsUnit unit2 = prepareTestUnit(true);
+    AcquisitionsUnit unit3 = prepareTestUnit(true);
+    // Add all acq units as mock data
+    addMockEntry(ACQUISITIONS_UNITS, unit1);
+    addMockEntry(ACQUISITIONS_UNITS, unit2);
+    addMockEntry(ACQUISITIONS_UNITS, unit3);
+
+    // Prepare invoice with 2 acq units (one is "soft deleted") and add it as mock data for update case
+    Invoice invoice = prepareInvoice(Arrays.asList(unit1.getId(), unit2.getId()));
+    
+    // Add the third unit to request
+    invoice.getAcqUnitIds().add(unit3.getId());
+    
+    Errors errors = operation.process(INVOICE_PATH, encodePrettily(invoice),
+        headers, APPLICATION_JSON, HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()).as(Errors.class);
+    
+    assertThat(errors.getErrors(), hasSize(1));
+    Error error = errors.getErrors().get(0);
+    assertThat(error.getCode(), equalTo(ACQ_UNITS_NOT_FOUND.getCode()));
+    assertThat(error.getAdditionalProperties().get(ACQUISITIONS_UNIT_IDS), instanceOf(List.class));
+    
+    // Verify number of sub-requests
+    validateNumberOfRequests(1, 0);
+
+    List<String> ids = (List<String>) error.getAdditionalProperties().get(ACQUISITIONS_UNIT_IDS);
+    if (operation == UPDATE) {
+      assertThat(ids, contains(unit3.getId()));
+    } else {
+      assertThat(ids, containsInAnyOrder(unit2.getId(), unit3.getId()));
+    }
+  }
+
+//  @Test
+//  @Parameters({
+////    "CREATE",
+//    "UPDATE"
+//  })
+//  public void testAssigningSoftDeletedUnit(ProtectedOperations operation) {
+//    logger.info("=== Test invoice contains \"soft deleted\" unit id - expecting of call only to Units API ===");
+//    
+//    final Headers headers = prepareHeaders(X_OKAPI_TENANT, ALL_DESIRED_PERMISSIONS_HEADER, X_OKAPI_USER_ID);
+//
+//    // Acq to order in storage for update case and
+//    AcquisitionsUnit unit1 = prepareTestUnit(false);
+//    AcquisitionsUnit unit2 = prepareTestUnit(false);
+//    AcquisitionsUnit unit3 = prepareTestUnit(false);
+//    // Add all acq units as mock data
+//    addMockEntry(ACQUISITIONS_UNITS, unit1);
+//    addMockEntry(ACQUISITIONS_UNITS, unit2);
+//    addMockEntry(ACQUISITIONS_UNITS, unit3);
+//
+//    // Prepare invoice with 2 acq units (one is "soft deleted") and add it as mock data for update case
+//    Invoice invoice = prepareInvoice(Arrays.asList(unit1.getId(), unit2.getId()));
+//    Invoice invoice2 = prepareInvoice(Arrays.asList(unit2.getId(), unit3.getId()));
+//    
+//    InvoiceLine invoiceLine1 = getMinimalContentInvoiceLine(invoice.getId());
+//    addMockEntry(INVOICE_LINES, JsonObject.mapFrom(invoiceLine1));
+//    InvoiceLine invoiceLine2 = getMinimalContentInvoiceLine(invoice.getId());
+//    InvoiceLine invoiceLine3 = getMinimalContentInvoiceLine(invoice.getId());
+//    addMockEntry(INVOICE_LINES, JsonObject.mapFrom(invoiceLine2));
+//    
+//    // Add the third unit to request
+//    invoice.getAcqUnitIds().add(unit3.getId());
+//    
+//    Errors errors = operation.process(INVOICE_PATH, encodePrettily(invoice),
+//        headers, APPLICATION_JSON, HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()).as(Errors.class);
+//    
+//    assertThat(errors.getErrors(), hasSize(1));
+//    Error error = errors.getErrors().get(0);
+//    assertThat(error.getCode(), equalTo(ACQ_UNITS_NOT_FOUND.getCode()));
+//    assertThat(error.getAdditionalProperties().get(ACQUISITIONS_UNIT_IDS), instanceOf(List.class));
+//    
+//    // Verify number of sub-requests
+//    validateNumberOfRequests(1, 0);
+//
+//    List<String> ids = (List<String>) error.getAdditionalProperties().get(ACQUISITIONS_UNIT_IDS);
+//    if (operation == UPDATE) {
+//      assertThat(ids, contains(unit3.getId()));
+//    } else {
+//      assertThat(ids, containsInAnyOrder(unit2.getId(), unit3.getId()));
+//    }
+//  }
+  @Test
+  public void testGetInvoiceWithAssignedSoftDeletedUnit() {
+    logger.info("=== Test invoice contains only \"soft deleted\" unit id - expecting of call only to Units API ===");
+
+    final Headers headers = prepareHeaders(X_OKAPI_TENANT, ALL_DESIRED_PERMISSIONS_HEADER, X_OKAPI_USER_ID); 
+    // Acq to order in storage for update case and
+    AcquisitionsUnit unit1 = prepareTestUnit(true);
+    // Add all acq units as mock data
+    addMockEntry(ACQUISITIONS_UNITS, unit1);
+
+    // Prepare order with one acq unit ("soft deleted")
+    Invoice invoice = prepareInvoice(Collections.singletonList(unit1.getId()));
+    
+    ProtectedOperations.READ.process(INVOICE_PATH, encodePrettily(invoice), headers, APPLICATION_JSON,
+        HttpStatus.HTTP_OK.toInt());
+    
+    // Verify number of sub-requests
+    validateNumberOfRequests(1, 0);
+    
+    // Verify that unit was deleted so logic skipped membership check
+    List<AcquisitionsUnit> acquisitionsUnits = MockServer.getAcqUnitsSearches()
+      .get(0)
+      .mapTo(AcquisitionsUnitCollection.class)
+      .getAcquisitionsUnits();
+    assertThat(acquisitionsUnits, hasSize(1));
+    assertThat(acquisitionsUnits.get(0).getIsDeleted(), is(true));
   }
 }

--- a/src/test/java/org/folio/rest/impl/protection/InvoicesProtectionTest.java
+++ b/src/test/java/org/folio/rest/impl/protection/InvoicesProtectionTest.java
@@ -137,7 +137,7 @@ public class InvoicesProtectionTest extends ProtectedEntityTestBase {
 
     validateNumberOfRequests(0, 0);
   }
-  
+
   @Test
   @Parameters({
     "CREATE",
@@ -182,56 +182,6 @@ public class InvoicesProtectionTest extends ProtectedEntityTestBase {
     }
   }
 
-//  @Test
-//  @Parameters({
-////    "CREATE",
-//    "UPDATE"
-//  })
-//  public void testAssigningSoftDeletedUnit(ProtectedOperations operation) {
-//    logger.info("=== Test invoice contains \"soft deleted\" unit id - expecting of call only to Units API ===");
-//    
-//    final Headers headers = prepareHeaders(X_OKAPI_TENANT, ALL_DESIRED_PERMISSIONS_HEADER, X_OKAPI_USER_ID);
-//
-//    // Acq to order in storage for update case and
-//    AcquisitionsUnit unit1 = prepareTestUnit(false);
-//    AcquisitionsUnit unit2 = prepareTestUnit(false);
-//    AcquisitionsUnit unit3 = prepareTestUnit(false);
-//    // Add all acq units as mock data
-//    addMockEntry(ACQUISITIONS_UNITS, unit1);
-//    addMockEntry(ACQUISITIONS_UNITS, unit2);
-//    addMockEntry(ACQUISITIONS_UNITS, unit3);
-//
-//    // Prepare invoice with 2 acq units (one is "soft deleted") and add it as mock data for update case
-//    Invoice invoice = prepareInvoice(Arrays.asList(unit1.getId(), unit2.getId()));
-//    Invoice invoice2 = prepareInvoice(Arrays.asList(unit2.getId(), unit3.getId()));
-//    
-//    InvoiceLine invoiceLine1 = getMinimalContentInvoiceLine(invoice.getId());
-//    addMockEntry(INVOICE_LINES, JsonObject.mapFrom(invoiceLine1));
-//    InvoiceLine invoiceLine2 = getMinimalContentInvoiceLine(invoice.getId());
-//    InvoiceLine invoiceLine3 = getMinimalContentInvoiceLine(invoice.getId());
-//    addMockEntry(INVOICE_LINES, JsonObject.mapFrom(invoiceLine2));
-//    
-//    // Add the third unit to request
-//    invoice.getAcqUnitIds().add(unit3.getId());
-//    
-//    Errors errors = operation.process(INVOICE_PATH, encodePrettily(invoice),
-//        headers, APPLICATION_JSON, HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()).as(Errors.class);
-//    
-//    assertThat(errors.getErrors(), hasSize(1));
-//    Error error = errors.getErrors().get(0);
-//    assertThat(error.getCode(), equalTo(ACQ_UNITS_NOT_FOUND.getCode()));
-//    assertThat(error.getAdditionalProperties().get(ACQUISITIONS_UNIT_IDS), instanceOf(List.class));
-//    
-//    // Verify number of sub-requests
-//    validateNumberOfRequests(1, 0);
-//
-//    List<String> ids = (List<String>) error.getAdditionalProperties().get(ACQUISITIONS_UNIT_IDS);
-//    if (operation == UPDATE) {
-//      assertThat(ids, contains(unit3.getId()));
-//    } else {
-//      assertThat(ids, containsInAnyOrder(unit2.getId(), unit3.getId()));
-//    }
-//  }
   @Test
   public void testGetInvoiceWithAssignedSoftDeletedUnit() {
     logger.info("=== Test invoice contains only \"soft deleted\" unit id - expecting of call only to Units API ===");

--- a/src/test/java/org/folio/rest/impl/protection/InvoicesProtectionTest.java
+++ b/src/test/java/org/folio/rest/impl/protection/InvoicesProtectionTest.java
@@ -188,7 +188,7 @@ public class InvoicesProtectionTest extends ProtectedEntityTestBase {
 
     final Headers headers = prepareHeaders(X_OKAPI_TENANT, ALL_DESIRED_PERMISSIONS_HEADER, X_OKAPI_USER_ID); 
     // Prepare acq unit in storage for update case
-    AcquisitionsUnit unit1 = prepareTestUnit(true);
+    AcquisitionsUnit unit1 = prepareTestUnit(true).withProtectRead(true);
     // Add all acq units as mock data
     addMockEntry(ACQUISITIONS_UNITS, unit1);
 

--- a/src/test/java/org/folio/rest/impl/protection/InvoicesProtectionTest.java
+++ b/src/test/java/org/folio/rest/impl/protection/InvoicesProtectionTest.java
@@ -148,7 +148,7 @@ public class InvoicesProtectionTest extends ProtectedEntityTestBase {
     
     final Headers headers = prepareHeaders(X_OKAPI_TENANT, ALL_DESIRED_PERMISSIONS_HEADER, X_OKAPI_USER_ID);
 
-    // Acq to order in storage for update case and
+    // Prepare acq unit in storage for update case and
     AcquisitionsUnit unit1 = prepareTestUnit(false);
     AcquisitionsUnit unit2 = prepareTestUnit(true);
     AcquisitionsUnit unit3 = prepareTestUnit(true);
@@ -187,12 +187,12 @@ public class InvoicesProtectionTest extends ProtectedEntityTestBase {
     logger.info("=== Test invoice contains only \"soft deleted\" unit id - expecting of call only to Units API ===");
 
     final Headers headers = prepareHeaders(X_OKAPI_TENANT, ALL_DESIRED_PERMISSIONS_HEADER, X_OKAPI_USER_ID); 
-    // Acq to order in storage for update case and
+    // Prepare acq unit in storage for update case
     AcquisitionsUnit unit1 = prepareTestUnit(true);
     // Add all acq units as mock data
     addMockEntry(ACQUISITIONS_UNITS, unit1);
 
-    // Prepare order with one acq unit ("soft deleted")
+    // Prepare invoice with one acq unit ("soft deleted")
     Invoice invoice = prepareInvoice(Collections.singletonList(unit1.getId()));
     
     ProtectedOperations.READ.process(INVOICE_PATH, encodePrettily(invoice), headers, APPLICATION_JSON,

--- a/src/test/java/org/folio/rest/impl/protection/LinesProtectionTest.java
+++ b/src/test/java/org/folio/rest/impl/protection/LinesProtectionTest.java
@@ -39,12 +39,11 @@ public class LinesProtectionTest extends ProtectedEntityTestBase {
 
     final Headers headers = prepareHeaders(X_OKAPI_TENANT, X_OKAPI_USER_ID);
     Errors errors = operation.process(INVOICE_LINES_PATH, encodePrettily(prepareInvoiceLine(NON_EXISTENT_UNITS)),
-      headers, APPLICATION_JSON, HttpStatus.HTTP_VALIDATION_ERROR.toInt()).as(Errors.class);
+      headers, APPLICATION_JSON, HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt()).as(Errors.class);
 
     assertThat(errors.getErrors(), hasSize(1));
     assertThat(errors.getErrors().get(0).getCode(), equalTo(ACQ_UNITS_NOT_FOUND.getCode()));
-    assertThat(errors.getErrors().get(0).getParameters(), hasSize(1));
-    assertThat(errors.getErrors().get(0).getParameters().get(0).getKey(), equalTo(ACQUISITIONS_UNIT_IDS));
+    
     // Verify number of sub-requests
     validateNumberOfRequests(1, 0);
   }

--- a/src/test/java/org/folio/rest/impl/protection/ProtectedEntityTestBase.java
+++ b/src/test/java/org/folio/rest/impl/protection/ProtectedEntityTestBase.java
@@ -9,11 +9,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import org.folio.invoices.utils.AcqDesiredPermissions;
+import org.folio.rest.acq.model.units.AcquisitionsUnit;
 import org.folio.rest.impl.ApiTestBase;
 import org.folio.rest.impl.MockServer;
 import org.folio.rest.jaxrs.model.Invoice;
@@ -54,7 +57,7 @@ public abstract class ProtectedEntityTestBase extends ApiTestBase {
 
   public Invoice prepareInvoice(List<String> acqUnitsIds) {
     Invoice invoice = getMinimalContentInvoice();
-    invoice.setAcqUnitIds(acqUnitsIds);
+    invoice.setAcqUnitIds(new ArrayList<>(acqUnitsIds));
     addMockEntry(INVOICES, JsonObject.mapFrom(invoice));
     return invoice;
   }
@@ -64,5 +67,10 @@ public abstract class ProtectedEntityTestBase extends ApiTestBase {
     InvoiceLine invoiceLine = getMinimalContentInvoiceLine(invoice.getId());
     addMockEntry(INVOICE_LINES, JsonObject.mapFrom(invoiceLine));
     return invoiceLine;
+  }
+  
+  public AcquisitionsUnit prepareTestUnit(boolean isDeleted) {
+    String id = UUID.randomUUID().toString();
+    return new AcquisitionsUnit().withId(id).withName(id).withIsDeleted(isDeleted);
   }
 }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/MODINVOICE-89

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- On invoice creation: in case any acq units assigned, check first if all exist and have `isDeleted==false`
- On invoice update: in case any acq units assigned, check that all newly assigned acq units (comparing to what is in storage) exist and have `isDeleted==false`
- Handle case when only one unit assigned to invoice and it has isDeleted==true - no need to check user memberships

In both cases above on failure, the flow is terminated and an error is returned to the client like following
```json
{
  "message": "Acquisitions units assigned to invoice not found",
  "code": "acqUnitsNotFound",
  "acqUnitIds": [
    "a968d9fe-1230-4c44-8e59-87cd462a06e4",
    "eab71dbd-b14b-4cfb-9b1e-d6f450b5b00f"
  ]
}
```

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
