### PR TITLE
MODINVOICE-120 - Voucher "accounting code" not set

### DIFF
--- a/src/main/java/org/folio/rest/impl/InvoiceHelper.java
+++ b/src/main/java/org/folio/rest/impl/InvoiceHelper.java
@@ -119,9 +119,6 @@ public class InvoiceHelper extends AbstractHelper {
   private static final String VOUCHER_NUMBER_CONFIG_QUERY = String.format(CONFIG_QUERY, INVOICE_CONFIG_MODULE_NAME, VOUCHER_NUMBER_CONFIG_NAME);
   private static final String GET_INVOICES_BY_QUERY = resourcesPath(INVOICES) + SEARCH_PARAMS;
   private static final String GET_FUNDS_BY_QUERY = resourcesPath(FUNDS) + "?query=%s&limit=%s&lang=%s";
-
-
-  private static final String DEFAULT_ACCOUNTING_CODE = "tmp_code";
   private static final String EMPTY_ARRAY = "[]";
 
   // Using variable to "cache" lines for particular invoice base on assumption that the helper is stateful and new instance is used
@@ -559,9 +556,9 @@ public class InvoiceHelper extends AbstractHelper {
 
     voucher.setInvoiceCurrency(invoice.getCurrency());
     voucher.setExportToAccounting(invoice.getExportToAccounting());
+    voucher.setAccountingCode(invoice.getAccountingCode());
 
     // TODO Start using real information to create a voucher when it becomes known where to get these values from.
-    voucher.setAccountingCode(DEFAULT_ACCOUNTING_CODE);
     voucher.setType(Voucher.Type.VOUCHER);
     voucher.setStatus(Voucher.Status.AWAITING_PAYMENT);
 

--- a/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
@@ -1094,7 +1094,7 @@ public class InvoicesApiTest extends ApiTestBase {
     assertThat(invoiceUpdate.getId(), equalTo(voucherCreated.getInvoiceId()));
     assertThat(invoiceUpdate.getCurrency(), equalTo(voucherCreated.getInvoiceCurrency()));
     assertThat(MonetaryConversions.getExchangeRateProvider().getExchangeRate(voucherCreated.getInvoiceCurrency(), voucherCreated.getSystemCurrency()).getFactor().doubleValue(), equalTo(voucherCreated.getExchangeRate()));
-    assertThat(voucherCreated.getAccountingCode(), notNullValue());
+    assertThat(voucherCreated.getAccountingCode(), equalTo(invoiceUpdate.getAccountingCode()));
     assertThat(voucherCreated.getExportToAccounting(), is(false));
     assertThat(Voucher.Status.AWAITING_PAYMENT, equalTo(voucherCreated.getStatus()));
     assertThat(Voucher.Type.VOUCHER, equalTo(voucherCreated.getType()));
@@ -1543,7 +1543,7 @@ public class InvoicesApiTest extends ApiTestBase {
   public void testCreateInvoiceWithTwoProratedAdjustmentsNoLines() throws IOException {
     logger.info(
         "=== Test create invoice with 1 prorated and 1 not prorated adjustments with no lines - adjustmentTotal should always be calculated irrespective if there are any invoiceLines or not===");
-    
+
     // === Preparing invoice for test ===
     Invoice invoice = new JsonObject(getMockData(REVIEWED_INVOICE_SAMPLE_PATH)).mapTo(Invoice.class);
 
@@ -1566,7 +1566,7 @@ public class InvoicesApiTest extends ApiTestBase {
 
     compareRecordWithSentToStorage(resp);
   }
-  
+
   @Test
   public void testCreateInvoiceWithLockedTotalAndTwoProratedAdjustments() throws IOException {
     logger.info("=== Test create invoice with locked total and 2 prorated adjustments ===");

--- a/src/test/java/org/folio/rest/impl/VouchersApiTest.java
+++ b/src/test/java/org/folio/rest/impl/VouchersApiTest.java
@@ -4,7 +4,6 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.folio.invoices.utils.HelperUtils.INVOICE_ID;
 import static org.folio.rest.impl.AbstractHelper.ID;
-import static org.folio.rest.impl.InvoicesApiTest.APPROVED_INVOICE_ID;
 import static org.folio.rest.impl.MockServer.ERROR_X_OKAPI_TENANT;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;


### PR DESCRIPTION
[MODINVOICE-120](https://issues.folio.org/browse/MODINVOICE-120) - Voucher "accounting code" not set

## Purpose
The voucher should be assigned an accounting code from the invoice. Currently it is given a temporary code.

## Approach
The voucher is assigned an accounting code from the invoice

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
