### PR TITLE
MODINVOICE-128 - fixing get by query

### DIFF
--- a/src/main/java/org/folio/rest/impl/BatchVoucherExportConfigHelper.java
+++ b/src/main/java/org/folio/rest/impl/BatchVoucherExportConfigHelper.java
@@ -1,5 +1,6 @@
 package org.folio.rest.impl;
 
+import static org.folio.invoices.utils.HelperUtils.getEndpointWithQuery;
 import static org.folio.invoices.utils.HelperUtils.getHttpClient;
 import static org.folio.invoices.utils.HelperUtils.handleDeleteRequest;
 import static org.folio.invoices.utils.HelperUtils.handleGetRequest;
@@ -70,7 +71,8 @@ public class BatchVoucherExportConfigHelper extends AbstractHelper {
   }
 
   public CompletableFuture<ExportConfigCollection> getExportConfigs(int limit, int offset, String query) {
-    String endpoint = String.format(GET_EXPORT_CONFIGS_BY_QUERY, limit, offset, query, lang);
+    String queryParam = getEndpointWithQuery(query, logger);
+    String endpoint = String.format(GET_EXPORT_CONFIGS_BY_QUERY, limit, offset, queryParam, lang);
     return handleGetRequest(endpoint, httpClient, ctx, okapiHeaders, logger)
       .thenCompose(json -> VertxCompletableFuture.supplyBlockingAsync(ctx, () -> json.mapTo(ExportConfigCollection.class)));
   }

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -128,6 +128,9 @@ public class MockServer {
   private static final String FUNDS_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "fundRecords/";
   private static final String VOUCHER_ID = "voucherId";
   private static final String QUERY = "query";
+  private static final String LIMIT = "limit";
+  private static final String OFFSET = "offset";
+  
   private static final String MOCK_DATA_INVOICES = "mockdata/invoices/invoices.json";
   static final String TEST_PREFIX = "testPrefix";
   private static final String INVALID_PREFIX = "12-prefix";
@@ -395,9 +398,24 @@ public class MockServer {
     }
   };
 
+  private void verifyIntegerParams(RoutingContext ctx, String[] params) {
+    for(String param : params) {
+      String value = StringUtils.trimToEmpty(ctx.request().getParam(param));
+      if(!StringUtils.isEmpty(value)) {
+        try {
+          Integer.parseInt(value);        
+        } catch (Exception e) {
+          serverResponse(ctx, 400, TEXT_PLAIN, String.format("For input String: %s", value));
+        }
+      }
+    }
+  }
+  
   private void handleGetBatchVoucherExportConfigs(RoutingContext ctx) {
     logger.info("handleGetBatchVoucherExportConfigs got: {}?{}", ctx.request().path(), ctx.request().query());
 
+    verifyIntegerParams(ctx, new String[] {LIMIT, OFFSET});  
+    
     String queryParam = StringUtils.trimToEmpty(ctx.request().getParam(QUERY));
     String tenant = ctx.request().getHeader(OKAPI_HEADER_TENANT);
     if (queryParam.contains(BAD_QUERY)) {


### PR DESCRIPTION
## Purpose
It was discovered during testing that there's an issue with GET export-configurations by query.  More specifically, the query arguments were mangled when forming the storage url to call.

e.g. `?query=batchGroupId==XYZ` resulted in `?limit=10&offset=0batchGroupId==XYZ`

For reference:  [MODINVOICE-128](https://issues.folio.org/browse/MODINVOICE-128)

## Approach
* Use `HelperUtils.getEndpointWithQuery(...)`
* Update unit tests to cover this case

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
