### PR TITLE
MODINVOICE-124

### DIFF
--- a/src/main/java/org/folio/rest/impl/InvoicesImpl.java
+++ b/src/main/java/org/folio/rest/impl/InvoicesImpl.java
@@ -41,7 +41,7 @@ public class InvoicesImpl implements org.folio.rest.jaxrs.resource.Invoice {
   public static final String PROTECTED_AND_MODIFIED_FIELDS = "protectedAndModifiedFields";
   private static final String DOCUMENTS_LOCATION_PREFIX = "/invoice/invoices/%s/documents/%s";
   private byte[] requestBytesArray = new byte[0];
-  private static final long MAX_DOCUMENT_SIZE = 25 * ONE_MB;
+  private static final long MAX_DOCUMENT_SIZE = 7 * ONE_MB;
 
   @Validate
   @Override


### PR DESCRIPTION
Follow up commit to [PR#125](https://github.com/folio-org/mod-invoice/pull/125) for limit document size decreasing to 5 Mb. Verified locally invoice API Tests (3 iterations) + 5 Mb request (300 iterations) with heap 256Mb:
<img width="1588" alt="image" src="https://user-images.githubusercontent.com/42964285/81116149-8a036500-8f2d-11ea-9de4-81e48ebe3570.png">
