### PR TITLE
MODINVOICE-199 Invoice line status is not updated

### DIFF
--- a/src/main/java/org/folio/services/adjusment/AdjustmentsService.java
+++ b/src/main/java/org/folio/services/adjusment/AdjustmentsService.java
@@ -81,19 +81,15 @@ public class AdjustmentsService {
       .collect(toList());
   }
 
-  public List<InvoiceLine> processProratedAdjustments(List<InvoiceLine> lines, Invoice invoice) {
+  public void processProratedAdjustments(List<InvoiceLine> lines, Invoice invoice) {
     List<Adjustment> proratedAdjustments = getProratedAdjustments(invoice);
 
     // Remove previously applied prorated adjustments if they are no longer available at invoice level
-    List<InvoiceLine> updatedLines = filterDeletedAdjustments(proratedAdjustments, lines);
+   filterDeletedAdjustments(proratedAdjustments, lines);
 
     // Apply prorated adjustments to each invoice line
-    updatedLines.addAll(applyProratedAdjustments(lines, invoice));
+   applyProratedAdjustments(lines, invoice);
 
-    // Return only unique invoice lines
-    return updatedLines.stream()
-      .distinct()
-      .collect(toList());
   }
 
   /**
@@ -101,15 +97,13 @@ public class AdjustmentsService {
    * @param proratedAdjustments list of prorated adjustments available at invoice level
    * @param invoiceLines list of invoice lines associated with current invoice
    */
-  List<InvoiceLine> filterDeletedAdjustments(List<Adjustment> proratedAdjustments, List<InvoiceLine> invoiceLines) {
+  void filterDeletedAdjustments(List<Adjustment> proratedAdjustments, List<InvoiceLine> invoiceLines) {
     List<String> adjIds = proratedAdjustments.stream()
       .map(Adjustment::getId)
       .collect(toList());
 
-    return invoiceLines.stream()
-      .filter(line -> line.getAdjustments()
-        .removeIf(adj -> Objects.nonNull(adj.getAdjustmentId()) && !adjIds.contains(adj.getAdjustmentId())))
-      .collect(toList());
+    invoiceLines.forEach(line -> line.getAdjustments()
+        .removeIf(adj -> Objects.nonNull(adj.getAdjustmentId()) && !adjIds.contains(adj.getAdjustmentId())));
   }
 
     /**


### PR DESCRIPTION
## Purpose
[MODINVOICE-199](https://issues.folio.org/browse/MODINVOICE-199)

## Approach
- update invoice lines status after invoice status transitions is finished
- removed invoceLines cache, as now lines will be retrieved only once

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
