### PR TITLE
MODINVOICE-205 Error must be returned in case of budget expense class mismatch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>3.0.0</version>
+      <version>3.4.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/folio/config/ServicesConfiguration.java
+++ b/src/main/java/org/folio/config/ServicesConfiguration.java
@@ -1,6 +1,7 @@
 package org.folio.config;
 
 import org.folio.rest.core.RestClient;
+import org.folio.services.expence.ExpenseClassRetrieveService;
 import org.folio.services.finance.BudgetExpenseClassService;
 import org.folio.services.config.TenantConfigurationService;
 import org.folio.services.exchange.ExchangeRateProviderResolver;
@@ -145,8 +146,11 @@ public class ServicesConfiguration {
   }
 
   @Bean
-  BudgetExpenseClassService budgetExpenseClassService(RestClient budgetExpenseClassRestClient) {
-    return new BudgetExpenseClassService(budgetExpenseClassRestClient);
+  BudgetExpenseClassService budgetExpenseClassService(RestClient budgetExpenseClassRestClient,
+                                                      FundService fundService,
+                                                      ExpenseClassRetrieveService expenseClassRetrieveService) {
+
+    return new BudgetExpenseClassService(budgetExpenseClassRestClient, fundService, expenseClassRetrieveService);
   }
 
   @Bean

--- a/src/main/java/org/folio/config/ServicesConfiguration.java
+++ b/src/main/java/org/folio/config/ServicesConfiguration.java
@@ -148,9 +148,10 @@ public class ServicesConfiguration {
   @Bean
   BudgetExpenseClassService budgetExpenseClassService(RestClient budgetExpenseClassRestClient,
                                                       FundService fundService,
-                                                      ExpenseClassRetrieveService expenseClassRetrieveService) {
+                                                      ExpenseClassRetrieveService expenseClassRetrieveService,
+                                                      RestClient activeBudgetRestClient) {
 
-    return new BudgetExpenseClassService(budgetExpenseClassRestClient, fundService, expenseClassRetrieveService);
+    return new BudgetExpenseClassService(budgetExpenseClassRestClient, fundService, expenseClassRetrieveService, activeBudgetRestClient);
   }
 
   @Bean

--- a/src/main/java/org/folio/invoices/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/invoices/utils/ErrorCodes.java
@@ -46,7 +46,8 @@ public enum ErrorCodes {
   INACTIVE_EXPENSE_CLASS("inactiveExpenseClass", "Expense class is Inactive"),
   ORDER_INVOICE_RELATION_CREATE_FAILED("orderInvoiceRelationCreateFailed", "Create of order invoice relation has been failed"),
   INVOICE_LINE_NOT_FOUND("invoiceLineNotFound", "Invoice line not found"),
-  BUDGET_EXPENSE_CLASS_NOT_FOUND("budgetExpenseClassNotFound", "Given expense class not assigned to the budget");
+  BUDGET_EXPENSE_CLASS_NOT_FOUND("budgetExpenseClassNotFound", "Given expense class not assigned to the budget"),
+  EXPENSE_CLASS_NOT_FOUND("expenseClassNotFound", "Expense class record is not found");
 
   private final String code;
   private final String description;

--- a/src/main/java/org/folio/services/expence/ExpenseClassRetrieveService.java
+++ b/src/main/java/org/folio/services/expence/ExpenseClassRetrieveService.java
@@ -1,7 +1,7 @@
 package org.folio.services.expence;
 
 import static java.util.stream.Collectors.toList;
-import static org.folio.invoices.utils.ErrorCodes.FUNDS_NOT_FOUND;
+import static org.folio.invoices.utils.ErrorCodes.EXPENSE_CLASS_NOT_FOUND;
 import static org.folio.invoices.utils.HelperUtils.collectResultsOnSuccess;
 import static org.folio.invoices.utils.HelperUtils.convertIdsToCqlQuery;
 import static org.folio.rest.RestConstants.MAX_IDS_FOR_GET_RQ;
@@ -18,9 +18,9 @@ import org.folio.rest.acq.model.finance.ExpenseClass;
 import org.folio.rest.acq.model.finance.ExpenseClassCollection;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.Parameter;
 
 import one.util.streamex.StreamEx;
-import org.folio.rest.jaxrs.model.Parameter;
 
 public class ExpenseClassRetrieveService {
   private final RestClient restClient;
@@ -51,7 +51,7 @@ public class ExpenseClassRetrieveService {
               Throwable cause = t.getCause() == null ? t : t.getCause();
               if (HelperUtils.isNotFound(cause)) {
                 List<Parameter> parameters = Collections.singletonList(new Parameter().withValue(id).withKey("expenseClass"));
-                throw new HttpException(404, FUNDS_NOT_FOUND.toError().withParameters(parameters));
+                  cause = new HttpException(404, EXPENSE_CLASS_NOT_FOUND.toError().withParameters(parameters));
               }
               throw new CompletionException(cause);
             });

--- a/src/main/java/org/folio/services/expence/ExpenseClassRetrieveService.java
+++ b/src/main/java/org/folio/services/expence/ExpenseClassRetrieveService.java
@@ -1,20 +1,26 @@
 package org.folio.services.expence;
 
 import static java.util.stream.Collectors.toList;
+import static org.folio.invoices.utils.ErrorCodes.FUNDS_NOT_FOUND;
 import static org.folio.invoices.utils.HelperUtils.collectResultsOnSuccess;
 import static org.folio.invoices.utils.HelperUtils.convertIdsToCqlQuery;
 import static org.folio.rest.RestConstants.MAX_IDS_FOR_GET_RQ;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
+import org.folio.invoices.rest.exceptions.HttpException;
+import org.folio.invoices.utils.HelperUtils;
 import org.folio.rest.acq.model.finance.ExpenseClass;
 import org.folio.rest.acq.model.finance.ExpenseClassCollection;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 
 import one.util.streamex.StreamEx;
+import org.folio.rest.jaxrs.model.Parameter;
 
 public class ExpenseClassRetrieveService {
   private final RestClient restClient;
@@ -40,7 +46,15 @@ public class ExpenseClassRetrieveService {
   }
 
   public CompletableFuture<ExpenseClass> getExpenseClassById(String id, RequestContext requestContext) {
-    return restClient.getById(id, requestContext, ExpenseClass.class);
+    return restClient.getById(id, requestContext, ExpenseClass.class)
+            .exceptionally(t -> {
+              Throwable cause = t.getCause() == null ? t : t.getCause();
+              if (HelperUtils.isNotFound(cause)) {
+                List<Parameter> parameters = Collections.singletonList(new Parameter().withValue(id).withKey("expenseClass"));
+                throw new HttpException(404, FUNDS_NOT_FOUND.toError().withParameters(parameters));
+              }
+              throw new CompletionException(cause);
+            });
   }
 
   private CompletableFuture<ExpenseClassCollection> getExpenseClassesChunk(List<String> expenseClassIds, RequestContext requestContext) {

--- a/src/main/java/org/folio/services/transaction/PaymentCreditWorkflowService.java
+++ b/src/main/java/org/folio/services/transaction/PaymentCreditWorkflowService.java
@@ -2,7 +2,6 @@ package org.folio.services.transaction;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.invoices.utils.ErrorCodes.TRANSACTION_CREATION_FAILURE;
-import static org.folio.services.finance.BudgetExpenseClassService.FUND_ID;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +30,8 @@ import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 public class PaymentCreditWorkflowService {
 
   private static final Logger logger = LoggerFactory.getLogger(PaymentCreditWorkflowService.class);
+
+  public static final String FUND_ID = "fundId";
 
   private final BaseTransactionService baseTransactionService;
   private final CurrentFiscalYearService currentFiscalYearService;

--- a/src/test/java/org/folio/ApiTestSuite.java
+++ b/src/test/java/org/folio/ApiTestSuite.java
@@ -35,6 +35,7 @@ import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.schemas.xsd.BatchVoucherSchemaXSDTest;
 import org.folio.services.InvoiceRetrieveServiceTest;
 import org.folio.services.VoucherLinesRetrieveServiceTest;
+import org.folio.services.expense.ExpenseClassRetrieveServiceTest;
 import org.folio.services.finance.BudgetExpenseClassTest;
 import org.folio.services.finance.BudgetValidationServiceTest;
 import org.folio.services.finance.CurrentFiscalYearServiceTest;
@@ -258,7 +259,13 @@ public class ApiTestSuite {
   @Nested
   class PendingPaymentWorkflowServiceTestNested extends PendingPaymentWorkflowServiceTest {
   }
+
   @Nested
   class BudgetExpenseClassTestNested extends BudgetExpenseClassTest {
+  }
+
+  @Nested
+  class ExpenseClassRetrieveServiceTestNested extends ExpenseClassRetrieveServiceTest {
+
   }
 }

--- a/src/test/java/org/folio/rest/core/RestClientTest.java
+++ b/src/test/java/org/folio/rest/core/RestClientTest.java
@@ -47,7 +47,7 @@ public class RestClientTest {
 
   @BeforeEach
   public void initMocks(){
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
     okapiHeaders = new HashMap<>();
     okapiHeaders.put(OKAPI_URL, "http://localhost:" + 8081);
     okapiHeaders.put(X_OKAPI_TOKEN.getName(), X_OKAPI_TOKEN.getValue());

--- a/src/test/java/org/folio/services/expense/ExpenseClassRetrieveServiceTest.java
+++ b/src/test/java/org/folio/services/expense/ExpenseClassRetrieveServiceTest.java
@@ -40,7 +40,7 @@ public class ExpenseClassRetrieveServiceTest {
 
     @BeforeEach
     public void initMocks() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test

--- a/src/test/java/org/folio/services/expense/ExpenseClassRetrieveServiceTest.java
+++ b/src/test/java/org/folio/services/expense/ExpenseClassRetrieveServiceTest.java
@@ -1,0 +1,68 @@
+package org.folio.services.expense;
+
+import static org.folio.invoices.utils.ErrorCodes.EXPENSE_CLASS_NOT_FOUND;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.folio.invoices.rest.exceptions.HttpException;
+import org.folio.rest.acq.model.finance.ExpenseClass;
+import org.folio.rest.core.RestClient;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.services.expence.ExpenseClassRetrieveService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ExpenseClassRetrieveServiceTest {
+
+    @InjectMocks
+    private ExpenseClassRetrieveService expenseClassRetrieveService;
+
+    @Mock
+    private RestClient restClient;
+
+    @Mock
+    private RequestContext requestContext;
+
+    @BeforeEach
+    public void initMocks() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void getExpenseClassByIdShouldReturnExpenseClassNotFoundWhenGetRestClientReturn404() {
+        CompletableFuture<ExpenseClass> future = new CompletableFuture<>();
+        future.completeExceptionally(new HttpException(404, "Not found"));
+        when(restClient.getById(anyString(), any(), eq(ExpenseClass.class))).thenReturn(future);
+        String expenseClassId = UUID.randomUUID().toString();
+        CompletableFuture<ExpenseClass> resultFuture = expenseClassRetrieveService.getExpenseClassById(expenseClassId, requestContext);
+
+        ExecutionException executionException = assertThrows(ExecutionException.class, resultFuture::get);
+
+        assertThat(executionException.getCause(), instanceOf(HttpException.class));
+
+        HttpException exception = (HttpException) executionException.getCause();
+
+        assertEquals(404, exception.getCode());
+        Errors errors = exception.getErrors();
+
+        Error error = errors.getErrors().get(0);
+        assertEquals(EXPENSE_CLASS_NOT_FOUND.getCode(), error.getCode());
+        assertEquals(expenseClassId, error.getParameters().get(0).getValue());
+
+    }
+}

--- a/src/test/java/org/folio/services/finance/BudgetExpenseClassTest.java
+++ b/src/test/java/org/folio/services/finance/BudgetExpenseClassTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import org.folio.invoices.rest.exceptions.HttpException;
+import org.folio.rest.acq.model.finance.Budget;
 import org.folio.rest.acq.model.finance.BudgetExpenseClass;
 import org.folio.rest.acq.model.finance.BudgetExpenseClassCollection;
 import org.folio.rest.acq.model.finance.ExpenseClass;
@@ -46,7 +47,6 @@ import io.vertx.core.Vertx;
 
 public class BudgetExpenseClassTest {
 
-    @InjectMocks
     private BudgetExpenseClassService budgetExpenseClassService;
 
     @Mock
@@ -59,11 +59,18 @@ public class BudgetExpenseClassTest {
     private ExpenseClassRetrieveService expenseClassRetrieveService;
 
     @Mock
+    private RestClient activeBudgetRestClient;
+
+    @Mock
     private RequestContext requestContext;
 
     @BeforeEach
     public void initMocks() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
+        budgetExpenseClassService = new BudgetExpenseClassService(budgetExpenseClassRestClient,
+                fundService,
+                expenseClassRetrieveService,
+                activeBudgetRestClient);
     }
 
     @Test
@@ -101,6 +108,9 @@ public class BudgetExpenseClassTest {
 
         Fund inactiveExpenseClassFund = new Fund().withCode("inactive fund");
         ExpenseClass inactiveExpenseClass = new ExpenseClass().withName("inactive class");
+
+        when(activeBudgetRestClient.getById(anyString(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(new Budget().withId(UUID.randomUUID().toString())));
 
         when(budgetExpenseClassRestClient.get(contains(inactiveExpenseClassId), anyInt(), anyInt(), ArgumentMatchers.any(), ArgumentMatchers.any()))
                 .thenReturn(CompletableFuture.completedFuture(new BudgetExpenseClassCollection()
@@ -164,6 +174,9 @@ public class BudgetExpenseClassTest {
 
         Fund noExpenseClassFund = new Fund().withCode("no expense class fund");
         ExpenseClass notAssignedExpenseClass = new ExpenseClass().withName("not assigned class");
+
+        when(activeBudgetRestClient.getById(anyString(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(new Budget().withId(UUID.randomUUID().toString())));
 
         when(budgetExpenseClassRestClient.get(contains(notAssignedExpenseClassId), anyInt(), anyInt(), ArgumentMatchers.any(), ArgumentMatchers.any()))
                 .thenReturn(CompletableFuture.completedFuture(new BudgetExpenseClassCollection()

--- a/src/test/java/org/folio/services/finance/BudgetExpenseClassTest.java
+++ b/src/test/java/org/folio/services/finance/BudgetExpenseClassTest.java
@@ -2,13 +2,15 @@ package org.folio.services.finance;
 
 import static org.folio.invoices.utils.ErrorCodes.BUDGET_EXPENSE_CLASS_NOT_FOUND;
 import static org.folio.invoices.utils.ErrorCodes.INACTIVE_EXPENSE_CLASS;
-import static org.folio.services.finance.BudgetExpenseClassService.EXPENSE_CLASS_ID;
-import static org.folio.services.finance.BudgetExpenseClassService.FUND_ID;
+import static org.folio.services.finance.BudgetExpenseClassService.EXPENSE_CLASS_NAME;
+import static org.folio.services.finance.BudgetExpenseClassService.FUND_CODE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.when;
 
@@ -22,6 +24,8 @@ import java.util.concurrent.ExecutionException;
 import org.folio.invoices.rest.exceptions.HttpException;
 import org.folio.rest.acq.model.finance.BudgetExpenseClass;
 import org.folio.rest.acq.model.finance.BudgetExpenseClassCollection;
+import org.folio.rest.acq.model.finance.ExpenseClass;
+import org.folio.rest.acq.model.finance.Fund;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.Adjustment;
@@ -30,6 +34,7 @@ import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.FundDistribution;
 import org.folio.rest.jaxrs.model.Invoice;
 import org.folio.rest.jaxrs.model.InvoiceLine;
+import org.folio.services.expence.ExpenseClassRetrieveService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -46,6 +51,12 @@ public class BudgetExpenseClassTest {
 
     @Mock
     private RestClient budgetExpenseClassRestClient;
+
+    @Mock
+    private FundService fundService;
+
+    @Mock
+    private ExpenseClassRetrieveService expenseClassRetrieveService;
 
     @Mock
     private RequestContext requestContext;
@@ -88,6 +99,9 @@ public class BudgetExpenseClassTest {
                 .withStatus(BudgetExpenseClass.Status.INACTIVE)
                 .withId(UUID.randomUUID().toString());
 
+        Fund inactiveExpenseClassFund = new Fund().withCode("inactive fund");
+        ExpenseClass inactiveExpenseClass = new ExpenseClass().withName("inactive class");
+
         when(budgetExpenseClassRestClient.get(contains(inactiveExpenseClassId), anyInt(), anyInt(), ArgumentMatchers.any(), ArgumentMatchers.any()))
                 .thenReturn(CompletableFuture.completedFuture(new BudgetExpenseClassCollection()
                         .withBudgetExpenseClasses(Collections.singletonList(inactive)).withTotalRecords(1)));
@@ -96,6 +110,9 @@ public class BudgetExpenseClassTest {
                 .thenReturn(CompletableFuture.completedFuture(new BudgetExpenseClassCollection()
                         .withBudgetExpenseClasses(Collections.singletonList(active)).withTotalRecords(1)));
         when(requestContext.getContext()).thenReturn(Vertx.vertx().getOrCreateContext());
+
+        when(fundService.getFundById(anyString(), any())).thenReturn(CompletableFuture.completedFuture(inactiveExpenseClassFund));
+        when(expenseClassRetrieveService.getExpenseClassById(anyString(), any())).thenReturn(CompletableFuture.completedFuture(inactiveExpenseClass));
 
         CompletableFuture<Void> future = budgetExpenseClassService.checkExpenseClasses(invoiceLines, invoice, requestContext);
 
@@ -110,10 +127,10 @@ public class BudgetExpenseClassTest {
 
         Error error = errors.getErrors().get(0);
         assertEquals(INACTIVE_EXPENSE_CLASS.getCode(), error.getCode());
-        String expenseClassIdFromError = error.getParameters().stream().filter(parameter -> parameter.getKey().equals(EXPENSE_CLASS_ID)).findFirst().get().getValue();
-        assertEquals(inactiveExpenseClassId, expenseClassIdFromError);
-        String fundIdFromError = error.getParameters().stream().filter(parameter -> parameter.getKey().equals(FUND_ID)).findFirst().get().getValue();
-        assertEquals(fundDistributionWithInactiveExpenseClass.getFundId(), fundIdFromError);
+        String expenseClassNameFromError = error.getParameters().stream().filter(parameter -> parameter.getKey().equals(EXPENSE_CLASS_NAME)).findFirst().get().getValue();
+        assertEquals(inactiveExpenseClass.getName(), expenseClassNameFromError);
+        String fundCodeFromError = error.getParameters().stream().filter(parameter -> parameter.getKey().equals(FUND_CODE)).findFirst().get().getValue();
+        assertEquals(inactiveExpenseClassFund.getCode(), fundCodeFromError);
     }
 
     @Test
@@ -145,6 +162,9 @@ public class BudgetExpenseClassTest {
                 .withStatus(BudgetExpenseClass.Status.ACTIVE)
                 .withId(UUID.randomUUID().toString());
 
+        Fund noExpenseClassFund = new Fund().withCode("no expense class fund");
+        ExpenseClass notAssignedExpenseClass = new ExpenseClass().withName("not assigned class");
+
         when(budgetExpenseClassRestClient.get(contains(notAssignedExpenseClassId), anyInt(), anyInt(), ArgumentMatchers.any(), ArgumentMatchers.any()))
                 .thenReturn(CompletableFuture.completedFuture(new BudgetExpenseClassCollection()
                         .withTotalRecords(0)));
@@ -153,6 +173,9 @@ public class BudgetExpenseClassTest {
                 .thenReturn(CompletableFuture.completedFuture(new BudgetExpenseClassCollection()
                         .withBudgetExpenseClasses(Collections.singletonList(active)).withTotalRecords(1)));
         when(requestContext.getContext()).thenReturn(Vertx.vertx().getOrCreateContext());
+
+        when(fundService.getFundById(anyString(), any())).thenReturn(CompletableFuture.completedFuture(noExpenseClassFund));
+        when(expenseClassRetrieveService.getExpenseClassById(anyString(), any())).thenReturn(CompletableFuture.completedFuture(notAssignedExpenseClass));
 
         CompletableFuture<Void> future = budgetExpenseClassService.checkExpenseClasses(invoiceLines, invoice, requestContext);
 
@@ -167,10 +190,10 @@ public class BudgetExpenseClassTest {
 
         Error error = errors.getErrors().get(0);
         assertEquals(BUDGET_EXPENSE_CLASS_NOT_FOUND.getCode(), error.getCode());
-        String expenseClassIdFromError = error.getParameters().stream().filter(parameter -> parameter.getKey().equals(EXPENSE_CLASS_ID)).findFirst().get().getValue();
-        assertEquals(notAssignedExpenseClassId, expenseClassIdFromError);
-        String fundIdFromError = error.getParameters().stream().filter(parameter -> parameter.getKey().equals(FUND_ID)).findFirst().get().getValue();
-        assertEquals(fundDistributionWithNotAssignedExpenseClass.getFundId(), fundIdFromError);
+        String expenseClassNameFromError = error.getParameters().stream().filter(parameter -> parameter.getKey().equals(EXPENSE_CLASS_NAME)).findFirst().get().getValue();
+        assertEquals(notAssignedExpenseClass.getName(), expenseClassNameFromError);
+        String fundCodeFromError = error.getParameters().stream().filter(parameter -> parameter.getKey().equals(FUND_CODE)).findFirst().get().getValue();
+        assertEquals(noExpenseClassFund.getCode(), fundCodeFromError);
     }
 
 }

--- a/src/test/java/org/folio/services/finance/BudgetValidationServiceTest.java
+++ b/src/test/java/org/folio/services/finance/BudgetValidationServiceTest.java
@@ -63,7 +63,7 @@ public class BudgetValidationServiceTest {
 
   @BeforeEach
   public void initMocks() {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
   }
 
   @Test

--- a/src/test/java/org/folio/services/finance/CurrentFiscalYearServiceTest.java
+++ b/src/test/java/org/folio/services/finance/CurrentFiscalYearServiceTest.java
@@ -42,7 +42,7 @@ public class CurrentFiscalYearServiceTest {
 
   @BeforeEach
   public void initMocks() {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
   }
 
   @Test

--- a/src/test/java/org/folio/services/transaction/BaseTransactionServiceTest.java
+++ b/src/test/java/org/folio/services/transaction/BaseTransactionServiceTest.java
@@ -47,7 +47,7 @@ public class BaseTransactionServiceTest extends ApiTestBase {
 
   @BeforeEach
   public void initMocks(){
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
     okapiHeaders = new HashMap<>();
     okapiHeaders.put(OKAPI_URL, "http://localhost:" + 8081);
     okapiHeaders.put(X_OKAPI_TOKEN.getName(), X_OKAPI_TOKEN.getValue());

--- a/src/test/java/org/folio/services/transaction/PendingPaymentWorkflowServiceTest.java
+++ b/src/test/java/org/folio/services/transaction/PendingPaymentWorkflowServiceTest.java
@@ -62,7 +62,7 @@ public class PendingPaymentWorkflowServiceTest {
 
   @BeforeEach
   public void initMocks() {
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
   }
 
   @Test

--- a/src/test/java/org/folio/services/voucher/UploadBatchVoucherExportServiceTest.java
+++ b/src/test/java/org/folio/services/voucher/UploadBatchVoucherExportServiceTest.java
@@ -56,7 +56,7 @@ public class UploadBatchVoucherExportServiceTest extends ApiTestBase {
 
   @BeforeEach
   public void initMocks(){
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
   }
 
 


### PR DESCRIPTION
## Purpose
[MODINVOICE-205](https://issues.folio.org/browse/MODINVOICE-205)
UI requires fundCode and expenseClass name instead of UUIDs in error's parameters


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
