### PR TITLE
MODINVOICE-282 Support max.request.size configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/src/main/java/org/folio/config/KafkaConsumersConfiguration.java
+++ b/src/main/java/org/folio/config/KafkaConsumersConfiguration.java
@@ -14,6 +14,8 @@ public class KafkaConsumersConfiguration {
   private String okapiUrl;
   @Value("${REPLICATION_FACTOR:1}")
   private int replicationFactor;
+  @Value("${MAX_REQUEST_SIZE:1048576}")
+  private int maxRequestSize;
   @Value("${ENV:folio}")
   private String envId;
 
@@ -25,6 +27,7 @@ public class KafkaConsumersConfiguration {
       .kafkaPort(kafkaPort)
       .okapiUrl(okapiUrl)
       .replicationFactor(replicationFactor)
+      .maxRequestSize(maxRequestSize)
       .build();
   }
 


### PR DESCRIPTION
When attempting to import a file the import job does not complete due to the following error
org.apache.kafka.common.errors.RecordTooLargeException: The message is 1287037 bytes when serialized which is larger than 1048576, which is the value of the max.request.size configuration.

Update to folio-kafka-wrapper v2.3.2 allows to set max.request.size parameter

https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#producerconfigs_max.request.size