### PR TITLE
MODDATAIMP-516 - EDIFACT invoice does not import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>3.1.3</version>
+      <version>3.2.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.mockftpserver</groupId>


### PR DESCRIPTION
When attempting to import file the import job is completed with errors.
To fix invoice import on the hosted envs, it is necessary to update the data-import-processing-core library version