### PR TITLE
MODINVOICE-290 - Release old POL encumbrances even if invoice line has changed funds

### DIFF
--- a/src/main/java/org/folio/config/ServicesConfiguration.java
+++ b/src/main/java/org/folio/config/ServicesConfiguration.java
@@ -102,9 +102,10 @@ public class ServicesConfiguration {
 
   @Bean
   PendingPaymentWorkflowService pendingPaymentService(BaseTransactionService baseTransactionService,
+                                                      EncumbranceService encumbranceService,
                                                       InvoiceTransactionSummaryService invoiceTransactionSummaryService,
                                                       FundAvailabilityHolderValidator fundAvailabilityValidator) {
-    return new PendingPaymentWorkflowService(baseTransactionService, invoiceTransactionSummaryService, fundAvailabilityValidator);
+    return new PendingPaymentWorkflowService(baseTransactionService, encumbranceService, invoiceTransactionSummaryService, fundAvailabilityValidator);
   }
 
   @Bean

--- a/src/main/java/org/folio/invoices/utils/ResourcePathResolver.java
+++ b/src/main/java/org/folio/invoices/utils/ResourcePathResolver.java
@@ -36,6 +36,7 @@ public class ResourcePathResolver {
   public static final String CURRENT_BUDGET = "finance.current-budgets";
   public static final String LEDGERS = "finance.ledgers";
   public static final String FINANCE_TRANSACTIONS = "finance/transactions";
+  public static final String FINANCE_RELEASE_ENCUMBRANCE = "finance/release-encumbrance";
   public static final String FINANCE_INVOICE_PAYMENTS_SUMMARIES = "finance/invoice-payment-summaries";
   public static final String FINANCE_PAYMENTS = "finance/payments";
   public static final String FINANCE_CREDITS ="finance/credits";
@@ -73,6 +74,7 @@ public class ResourcePathResolver {
     apis.put(BATCH_VOUCHER_STORAGE, "/batch-voucher-storage/batch-vouchers");
     apis.put(BATCH_VOUCHER_EXPORTS_STORAGE, "/batch-voucher-storage/batch-voucher-exports");
     apis.put(FINANCE_TRANSACTIONS, "/finance/transactions");
+    apis.put(FINANCE_RELEASE_ENCUMBRANCE, "/finance/release-encumbrance");
     apis.put(FINANCE_STORAGE_TRANSACTIONS, "/finance-storage/transactions");
     apis.put(FINANCE_INVOICE_PAYMENTS_SUMMARIES, "/finance/invoice-payment-summaries");
     apis.put(FINANCE_PAYMENTS, "/finance/payments");

--- a/src/main/java/org/folio/services/finance/transaction/BaseTransactionService.java
+++ b/src/main/java/org/folio/services/finance/transaction/BaseTransactionService.java
@@ -3,6 +3,7 @@ package org.folio.services.finance.transaction;
 import static java.util.stream.Collectors.toList;
 import static org.folio.invoices.utils.HelperUtils.collectResultsOnSuccess;
 import static org.folio.invoices.utils.HelperUtils.convertIdsToCqlQuery;
+import static org.folio.invoices.utils.ResourcePathResolver.FINANCE_RELEASE_ENCUMBRANCE;
 import static org.folio.invoices.utils.ResourcePathResolver.FINANCE_TRANSACTIONS;
 import static org.folio.invoices.utils.ResourcePathResolver.resourcesPath;
 import static org.folio.rest.RestConstants.MAX_IDS_FOR_GET_RQ;
@@ -95,6 +96,11 @@ public class BaseTransactionService {
 
   public String getByIdEndpoint(Transaction transaction) {
     return TRANSACTION_ENDPOINTS.get(transaction.getTransactionType()) + "/{id}";
+  }
+
+  public CompletableFuture<Void> releaseEncumbrance(Transaction transaction, RequestContext requestContext) {
+    RequestEntry requestEntry = new RequestEntry(resourcesPath(FINANCE_RELEASE_ENCUMBRANCE) + "/{id}").withId(transaction.getId());
+    return restClient.post(requestEntry, null, requestContext, Void.class);
   }
 
 }


### PR DESCRIPTION
## Purpose
Fix a problem with encumbrances not being released for POL if invoice line created for that POL was edited to use different funds even if invoice that is being approved is set to release encumbrances.

## Approach
- When approving invoice search every POL for encumbrances that don't have same fund ID and POL ID as any of encumbrances in the invoice lines.
- Release such encumbrances.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
