### PR TITLE
MODINVOICE-251 - Remove zipping mechanism for data import event payloads and use cache for params

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 5.2.0 - Unrleased
+* [MODINVOICE-251](https://issues.folio.org/browse/MODINVOICE-251) - Remove zipping mechanism for data-import event payloads and use cache for job profile snapshot
 
 ## 5.1.0 - Released
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -596,6 +596,10 @@
     {
       "id" : "orders-storage.order-invoice-relationships",
       "version": "1.0"
+    },
+    {
+      "id": "data-import-converter-storage",
+      "version": "1.2"
     }
   ],
   "permissionSets": [

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.3.2</version>
+      <version>2.4.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,17 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>3.1.4</version>
+      <version>3.2.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>mod-data-import-converter-storage-client</artifactId>
+      <version>1.12.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>2.9.0</version>
     </dependency>
     <dependency>
       <groupId>org.mockftpserver</groupId>

--- a/src/main/java/org/folio/dataimport/cache/CacheLoadingException.java
+++ b/src/main/java/org/folio/dataimport/cache/CacheLoadingException.java
@@ -1,0 +1,8 @@
+package org.folio.dataimport.cache;
+
+public class CacheLoadingException extends RuntimeException {
+
+  public CacheLoadingException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/folio/dataimport/cache/JobProfileSnapshotCache.java
+++ b/src/main/java/org/folio/dataimport/cache/JobProfileSnapshotCache.java
@@ -1,0 +1,76 @@
+package org.folio.dataimport.cache;
+
+import com.github.benmanes.caffeine.cache.AsyncCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.vertx.core.Vertx;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.HttpStatus;
+import org.folio.rest.RestConstants;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.client.DataImportProfilesClient;
+import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+
+@Component
+public class JobProfileSnapshotCache {
+
+  private static final Logger logger = LogManager.getLogger(JobProfileSnapshotCache.class);
+
+  @Value("${mod.invoice.profile-snapshot-cache.expiration.time.seconds:3600}")
+  private long cacheExpirationTime;
+
+  private AsyncCache<String, Optional<ProfileSnapshotWrapper>> cache;
+
+  @Autowired
+  public JobProfileSnapshotCache(Vertx vertx) {
+    cache = Caffeine.newBuilder()
+      .expireAfterAccess(cacheExpirationTime, TimeUnit.SECONDS)
+      .executor(task -> vertx.runOnContext(v -> task.run()))
+      .buildAsync();
+  }
+
+  public CompletableFuture<Optional<ProfileSnapshotWrapper>> get(String profileSnapshotId, Map<String, String> okapiHeaders) {
+    try {
+      return cache.get(profileSnapshotId, (key, executor) -> loadJobProfileSnapshot(key, okapiHeaders));
+    } catch (Exception e) {
+      logger.warn("Error loading ProfileSnapshotWrapper by id: '{}'", profileSnapshotId, e);
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  private CompletableFuture<Optional<ProfileSnapshotWrapper>> loadJobProfileSnapshot(String profileSnapshotId, Map<String, String> okapiHeaders) {
+    String okapiUrl = okapiHeaders.get(RestConstants.OKAPI_URL);
+    String tenant = okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT);
+    logger.debug("Trying to load jobProfileSnapshot by id  '{}' for cache, okapi url: {}, tenantId: {}", profileSnapshotId, okapiUrl, tenant);
+    DataImportProfilesClient client = new DataImportProfilesClient(okapiUrl, tenant, okapiHeaders.get(OKAPI_HEADER_TOKEN));
+
+    return client.getDataImportProfilesJobProfileSnapshotsById(profileSnapshotId)
+      .toCompletionStage()
+      .toCompletableFuture()
+      .thenCompose(httpResponse -> {
+        if (httpResponse.statusCode() == HttpStatus.HTTP_OK.toInt()) {
+          logger.info("JobProfileSnapshot was loaded by id '{}'", profileSnapshotId);
+          return CompletableFuture.completedFuture(Optional.of(httpResponse.bodyAsJson(ProfileSnapshotWrapper.class)));
+        } else if (httpResponse.statusCode() == HttpStatus.HTTP_NOT_FOUND.toInt()) {
+          logger.warn("JobProfileSnapshot was not found by id '{}'", profileSnapshotId);
+          return CompletableFuture.completedFuture(Optional.empty());
+        } else {
+          String message = String.format("Error loading jobProfileSnapshot by id: '%s', status code: %s, response message: %s",
+            profileSnapshotId, httpResponse.statusCode(), httpResponse.bodyAsString());
+          logger.warn(message);
+          return CompletableFuture.failedFuture(new CacheLoadingException(message));
+        }
+      });
+  }
+
+}

--- a/src/main/java/org/folio/dataimport/handlers/actions/CreateInvoiceEventHandler.java
+++ b/src/main/java/org/folio/dataimport/handlers/actions/CreateInvoiceEventHandler.java
@@ -35,6 +35,7 @@ import org.folio.Record;
 import org.folio.processing.events.services.handler.EventHandler;
 import org.folio.processing.exceptions.EventProcessingException;
 import org.folio.processing.mapping.MappingManager;
+import org.folio.processing.mapping.mapper.MappingContext;
 import org.folio.processing.mapping.mapper.reader.record.edifact.EdifactRecordReader;
 import org.folio.rest.RestConstants;
 import org.folio.rest.RestVerticle;
@@ -101,7 +102,7 @@ public class CreateInvoiceEventHandler implements EventHandler {
       poLinesFuture
         .thenAccept(invLineNoToPoLine -> ensureAdditionalData(dataImportEventPayload, invLineNoToPoLine))
         .thenAccept(v -> prepareEventPayloadForMapping(dataImportEventPayload))
-        .thenAccept(v -> MappingManager.map(dataImportEventPayload))
+        .thenAccept(v -> MappingManager.map(dataImportEventPayload, new MappingContext()))
         .thenAccept(v -> prepareMappingResult(dataImportEventPayload))
         .thenCompose(v -> saveInvoice(dataImportEventPayload, okapiHeaders))
         .thenApply(savedInvoice -> prepareInvoiceLinesToSave(savedInvoice.getId(), dataImportEventPayload, poLinesFuture.join()))

--- a/src/main/java/org/folio/dataimport/handlers/events/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/dataimport/handlers/events/DataImportKafkaHandler.java
@@ -1,37 +1,49 @@
 package org.folio.dataimport.handlers.events;
 
-import static org.folio.DataImportEventTypes.DI_ERROR;
-
-import java.io.IOException;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.folio.DataImportEventPayload;
-import org.folio.dataimport.InvoiceWriterFactory;
-import org.folio.dataimport.handlers.actions.CreateInvoiceEventHandler;
-import org.folio.kafka.AsyncRecordHandler;
-import org.folio.processing.events.EventManager;
-import org.folio.processing.events.utils.ZIPArchiver;
-import org.folio.processing.mapping.MappingManager;
-import org.folio.processing.mapping.mapper.reader.record.edifact.EdifactReaderFactory;
-import org.folio.rest.core.RestClient;
-import org.folio.rest.jaxrs.model.Event;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.DataImportEventPayload;
+import org.folio.dataimport.InvoiceWriterFactory;
+import org.folio.dataimport.cache.JobProfileSnapshotCache;
+import org.folio.dataimport.handlers.actions.CreateInvoiceEventHandler;
+import org.folio.kafka.AsyncRecordHandler;
+import org.folio.processing.events.EventManager;
+import org.folio.processing.events.utils.ZIPArchiver;
+import org.folio.processing.exceptions.EventProcessingException;
+import org.folio.processing.mapping.MappingManager;
+import org.folio.processing.mapping.mapper.reader.record.edifact.EdifactReaderFactory;
+import org.folio.rest.RestConstants;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.core.RestClient;
+import org.folio.rest.jaxrs.model.Event;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static java.lang.String.format;
+import static org.folio.DataImportEventTypes.DI_ERROR;
 
 @Component
 public class DataImportKafkaHandler implements AsyncRecordHandler<String, String> {
 
+  public static final String JOB_PROFILE_SNAPSHOT_ID_KEY = "JOB_PROFILE_SNAPSHOT_ID";
+  private static final String PROFILE_SNAPSHOT_NOT_FOUND_MSG = "JobProfileSnapshot was not found by id '%s'";
+
   private final Logger logger = LogManager.getLogger(DataImportKafkaHandler.class);
 
+  private final JobProfileSnapshotCache profileSnapshotCache;
+
   @Autowired
-  public DataImportKafkaHandler(RestClient restClient) {
+  public DataImportKafkaHandler(RestClient restClient, JobProfileSnapshotCache profileSnapshotCache) {
+    this.profileSnapshotCache = profileSnapshotCache;
     MappingManager.registerReaderFactory(new EdifactReaderFactory());
     MappingManager.registerWriterFactory(new InvoiceWriterFactory());
     EventManager.registerEventHandler(new CreateInvoiceEventHandler(restClient));
@@ -45,19 +57,32 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
       DataImportEventPayload eventPayload = new JsonObject(ZIPArchiver.unzip(event.getEventPayload())).mapTo(DataImportEventPayload.class);
       logger.info("Data import event payload has been received with event type: {}", eventPayload.getEventType());
 
-      EventManager.handleEvent(eventPayload).whenComplete((processedPayload, throwable) -> {
-        if (throwable != null) {
-          promise.fail(throwable);
-        } else if (DI_ERROR.value().equals(processedPayload.getEventType())) {
-          promise.fail("Failed to process data import event payload");
-        } else {
-          promise.complete(kafkaRecord.key());
-        }
-      });
+      String profileSnapshotId = eventPayload.getContext().get(JOB_PROFILE_SNAPSHOT_ID_KEY);
+      Map<String, String> okapiHeaders = retrieveOkapiHeaders(eventPayload);
+
+      profileSnapshotCache.get(profileSnapshotId, okapiHeaders)
+        .thenCompose(snapshotOptional -> snapshotOptional
+          .map(profileSnapshot -> EventManager.handleEvent(eventPayload, profileSnapshot))
+          .orElse(CompletableFuture.failedFuture(new EventProcessingException(format(PROFILE_SNAPSHOT_NOT_FOUND_MSG, profileSnapshotId)))))
+        .whenComplete((processedPayload, throwable) -> {
+          if (throwable != null) {
+            promise.fail(throwable);
+          } else if (DI_ERROR.value().equals(processedPayload.getEventType())) {
+            promise.fail("Failed to process data import event payload");
+          } else {
+            promise.complete(kafkaRecord.key());
+          }
+        });
       return promise.future();
     } catch (IOException e) {
       logger.error("Failed to process data import kafka record from topic {}", kafkaRecord.topic(), e);
       return Future.failedFuture(e);
     }
+  }
+
+  private Map<String, String> retrieveOkapiHeaders(DataImportEventPayload eventPayload) {
+    return Map.of(RestConstants.OKAPI_URL, eventPayload.getOkapiUrl(),
+      RestVerticle.OKAPI_HEADER_TENANT, eventPayload.getTenant(),
+      RestVerticle.OKAPI_HEADER_TOKEN, eventPayload.getToken());
   }
 }

--- a/src/main/java/org/folio/dataimport/handlers/events/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/dataimport/handlers/events/DataImportKafkaHandler.java
@@ -2,7 +2,7 @@ package org.folio.dataimport.handlers.events;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import org.apache.logging.log4j.LogManager;
@@ -13,7 +13,6 @@ import org.folio.dataimport.cache.JobProfileSnapshotCache;
 import org.folio.dataimport.handlers.actions.CreateInvoiceEventHandler;
 import org.folio.kafka.AsyncRecordHandler;
 import org.folio.processing.events.EventManager;
-import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.processing.exceptions.EventProcessingException;
 import org.folio.processing.mapping.MappingManager;
 import org.folio.processing.mapping.mapper.reader.record.edifact.EdifactReaderFactory;
@@ -54,7 +53,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
     try {
       Promise<String> promise = Promise.promise();
       Event event = DatabindCodec.mapper().readValue(kafkaRecord.value(), Event.class);
-      DataImportEventPayload eventPayload = new JsonObject(ZIPArchiver.unzip(event.getEventPayload())).mapTo(DataImportEventPayload.class);
+      DataImportEventPayload eventPayload = Json.decodeValue(event.getEventPayload(), DataImportEventPayload.class);
       logger.info("Data import event payload has been received with event type: {}", eventPayload.getEventType());
 
       String profileSnapshotId = eventPayload.getContext().get(JOB_PROFILE_SNAPSHOT_ID_KEY);

--- a/src/test/java/org/folio/ApiTestSuite.java
+++ b/src/test/java/org/folio/ApiTestSuite.java
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeoutException;
 import org.folio.converters.BatchVoucherModelConverterTest;
 import org.folio.converters.BatchedVoucherLinesModelConverterTest;
 import org.folio.converters.BatchedVoucherModelConverterTest;
+import org.folio.dataimport.cache.JobProfileSnapshotCacheTest;
 import org.folio.dataimport.handlers.actions.CreateInvoiceEventHandlerTest;
 import org.folio.invoices.util.HelperUtilsTest;
 import org.folio.jaxb.DefaultJAXBRootElementNameResolverTest;
@@ -288,6 +289,10 @@ public class ApiTestSuite {
 
   @Nested
   class CreateInvoiceEventHandlerTestNested extends CreateInvoiceEventHandlerTest {
+  }
+
+  @Nested
+  class JobProfileSnapshotCacheTestNested extends JobProfileSnapshotCacheTest {
   }
 
   @Nested

--- a/src/test/java/org/folio/dataimport/cache/JobProfileSnapshotCacheTest.java
+++ b/src/test/java/org/folio/dataimport/cache/JobProfileSnapshotCacheTest.java
@@ -1,0 +1,95 @@
+package org.folio.dataimport.cache;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.junit5.VertxExtension;
+import org.folio.ApiTestSuite;
+import org.folio.rest.RestConstants;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.impl.ApiTestBase;
+import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+import org.junit.Rule;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.folio.rest.impl.MockServer.addMockEntry;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
+
+@ExtendWith(VertxExtension.class)
+public class JobProfileSnapshotCacheTest extends ApiTestBase {
+
+  @Rule
+  public RunTestOnContext rule = new RunTestOnContext();
+
+  private static final String TENANT_ID = "diku";
+  private static final String JOB_PROFILE_SNAPSHOTS_MOCK = "jobProfileSnapshots";
+  private static final String SNAPSHOT_ID_FOR_INTERNAL_SERVER_ERROR = "168f8a86-d26c-406e-813f-c7527f241ac3";
+
+  private Vertx vertx = Vertx.vertx();
+  private JobProfileSnapshotCache jobProfileSnapshotCache = new JobProfileSnapshotCache(vertx);
+
+  ProfileSnapshotWrapper jobProfileSnapshot = new ProfileSnapshotWrapper()
+    .withId(UUID.randomUUID().toString())
+    .withContentType(JOB_PROFILE)
+    .withChildSnapshotWrappers(List.of(new ProfileSnapshotWrapper()
+      .withId(UUID.randomUUID().toString())
+      .withContentType(ACTION_PROFILE)));
+
+  private Map<String, String> okapiHeaders;
+
+  @BeforeEach
+  public void setUp() {
+    this.okapiHeaders = Map.of(
+      RestVerticle.OKAPI_HEADER_TENANT, TENANT_ID,
+      RestVerticle.OKAPI_HEADER_TOKEN, "token",
+      RestConstants.OKAPI_URL, "http://localhost:" + ApiTestSuite.mockPort);
+  }
+
+  @Test
+  public void shouldReturnProfileSnapshot() throws InterruptedException, ExecutionException, TimeoutException {
+    addMockEntry(JOB_PROFILE_SNAPSHOTS_MOCK, jobProfileSnapshot);
+
+    CompletableFuture<Optional<ProfileSnapshotWrapper>> optionalFuture = jobProfileSnapshotCache.get(jobProfileSnapshot.getId(), this.okapiHeaders);
+
+    Optional<ProfileSnapshotWrapper> profileOptional = optionalFuture.get(5, TimeUnit.SECONDS);
+    Assertions.assertTrue(profileOptional.isPresent());
+    ProfileSnapshotWrapper actualProfileSnapshot = profileOptional.get();
+    Assertions.assertEquals(jobProfileSnapshot.getId(), actualProfileSnapshot.getId());
+    Assertions.assertFalse(actualProfileSnapshot.getChildSnapshotWrappers().isEmpty());
+    Assertions.assertEquals(jobProfileSnapshot.getChildSnapshotWrappers().get(0).getId(),
+      actualProfileSnapshot.getChildSnapshotWrappers().get(0).getId());
+  }
+
+  @Test
+  public void shouldReturnEmptyOptionalWhenGetNotFoundOnSnapshotLoading() throws InterruptedException, ExecutionException, TimeoutException {
+    CompletableFuture<Optional<ProfileSnapshotWrapper>> optionalFuture = jobProfileSnapshotCache.get(jobProfileSnapshot.getId(), this.okapiHeaders);
+
+    Optional<ProfileSnapshotWrapper> profileOptional = optionalFuture.get(5, TimeUnit.SECONDS);
+    Assertions.assertTrue(profileOptional.isEmpty());
+  }
+
+  @Test
+  public void shouldReturnFailedFutureWhenGetServerErrorOnSnapshotLoading() {
+    CompletableFuture<Optional<ProfileSnapshotWrapper>> optionalFuture = jobProfileSnapshotCache.get(SNAPSHOT_ID_FOR_INTERNAL_SERVER_ERROR, this.okapiHeaders);
+    Assertions.assertThrows(ExecutionException.class, () -> optionalFuture.get(5, TimeUnit.SECONDS));
+  }
+
+  @Test
+  public void shouldReturnFailedFutureWhenSpecifiedProfileSnapshotIdIsNull() {
+    CompletableFuture<Optional<ProfileSnapshotWrapper>> optionalFuture = jobProfileSnapshotCache.get(null, this.okapiHeaders);
+    Assertions.assertThrows(ExecutionException.class, () -> optionalFuture.get(5, TimeUnit.SECONDS));
+  }
+
+}

--- a/src/test/java/org/folio/dataimport/handlers/actions/CreateInvoiceEventHandlerTest.java
+++ b/src/test/java/org/folio/dataimport/handlers/actions/CreateInvoiceEventHandlerTest.java
@@ -242,7 +242,7 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
   }
 
   @Test
-  public void shouldCreateInvoiceAndPublishDiCompletedEvent() throws IOException, InterruptedException {
+  public void shouldCreateInvoiceAndPublishDiCompletedEvent() throws InterruptedException {
     // given
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(EDIFACT_PARSED_CONTENT));
     ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfile);
@@ -662,7 +662,7 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
   }
 
   @Test
-  public void shouldPublishDiErrorEventWhenPostInvoiceToStorageFailed() throws IOException, InterruptedException {
+  public void shouldPublishDiErrorEventWhenPostInvoiceToStorageFailed() throws InterruptedException {
     // given
     ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfile);
     addMockEntry(JOB_PROFILE_SNAPSHOTS_MOCK, profileSnapshotWrapper);
@@ -764,7 +764,7 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
   }
 
   @Test
-  public void shouldPublishDiErrorWhenMappingProfileHasInvalidMappingSyntax() throws IOException, InterruptedException {
+  public void shouldPublishDiErrorWhenMappingProfileHasInvalidMappingSyntax() throws InterruptedException {
     // given
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_INVOICE_LINE_3_HAS_NO_SUBTOTAL));
     ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfileWithInvalidMappingSyntax);

--- a/src/test/java/org/folio/dataimport/handlers/actions/CreateInvoiceEventHandlerTest.java
+++ b/src/test/java/org/folio/dataimport/handlers/actions/CreateInvoiceEventHandlerTest.java
@@ -20,7 +20,6 @@ import org.folio.Record;
 import org.folio.kafka.KafkaTopicNameHelper;
 import org.folio.processing.events.EventManager;
 import org.folio.processing.events.services.handler.EventHandler;
-import org.folio.processing.events.utils.ZIPArchiver;
 import org.folio.rest.acq.model.orders.PoLine;
 import org.folio.rest.acq.model.orders.PoLineCollection;
 import org.folio.rest.core.RestClient;
@@ -63,6 +62,7 @@ import static org.folio.rest.impl.MockServer.DI_POST_INVOICE_LINES_SUCCESS_TENAN
 import static org.folio.rest.impl.MockServer.ERROR_TENANT;
 import static org.folio.rest.impl.MockServer.MOCK_DATA_PATH_PATTERN;
 import static org.folio.rest.impl.MockServer.PO_LINES_MOCK_DATA_PATH;
+import static org.folio.rest.impl.MockServer.addMockEntry;
 import static org.folio.rest.jaxrs.model.EntityType.EDIFACT_INVOICE;
 import static org.folio.rest.jaxrs.model.EntityType.INVOICE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
@@ -93,6 +93,8 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
   private static final String PO_LINE_ID_1 = "0000edd1-b463-41ba-bf64-1b1d9f9d0001";
   private static final String PO_LINE_ID_3 = "0000edd1-b463-41ba-bf64-1b1d9f9d0003";
   private static final String GROUP_ID = "test-consumers-group";
+  private static final String JOB_PROFILE_SNAPSHOTS_MOCK = "jobProfileSnapshots";
+  private static final String JOB_PROFILE_SNAPSHOT_ID_KEY = "JOB_PROFILE_SNAPSHOT_ID";
   public static final String ERROR_MSG_KEY = "ERROR";
 
   private JobProfile jobProfile = new JobProfile()
@@ -243,21 +245,22 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
   public void shouldCreateInvoiceAndPublishDiCompletedEvent() throws IOException, InterruptedException {
     // given
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(EDIFACT_PARSED_CONTENT));
+    ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfile);
+    addMockEntry(JOB_PROFILE_SNAPSHOTS_MOCK, profileSnapshotWrapper);
+
     HashMap<String, String> payloadContext = new HashMap<>();
     payloadContext.put(EDIFACT_INVOICE.value(), Json.encode(record));
-
-    ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfile);
+    payloadContext.put(JOB_PROFILE_SNAPSHOT_ID_KEY, profileSnapshotWrapper.getId());
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_EDIFACT_RECORD_CREATED.value())
       .withTenant(DI_POST_INVOICE_LINES_SUCCESS_TENANT)
       .withOkapiUrl(OKAPI_URL)
       .withToken(TOKEN)
-      .withContext(payloadContext)
-      .withProfileSnapshot(profileSnapshotWrapper);
+      .withContext(payloadContext);
 
     String topic = KafkaTopicNameHelper.formatTopicName(KAFKA_ENV_VALUE, getDefaultNameSpace(), DI_POST_INVOICE_LINES_SUCCESS_TENANT, dataImportEventPayload.getEventType());
-    Event event = new Event().withEventPayload(ZIPArchiver.zip(Json.encode(dataImportEventPayload)));
+    Event event = new Event().withEventPayload(Json.encode(dataImportEventPayload));
     KeyValue<String, String> kafkaRecord = new KeyValue<>("test-key", Json.encode(event));
     SendKeyValues<String, String> request = SendKeyValues.to(topic, Collections.singletonList(kafkaRecord))
       .useDefaults();
@@ -274,7 +277,7 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
       .build());
 
     Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
-    DataImportEventPayload eventPayload = Json.decodeValue(ZIPArchiver.unzip(obtainedEvent.getEventPayload()), DataImportEventPayload.class);
+    DataImportEventPayload eventPayload = Json.decodeValue(obtainedEvent.getEventPayload(), DataImportEventPayload.class);
     assertEquals(DI_INVOICE_CREATED.value(), eventPayload.getEventsChain().get(eventPayload.getEventsChain().size() -1));
 
     assertNotNull(eventPayload.getContext().get(INVOICE.value()));
@@ -306,21 +309,22 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
       .thenReturn(CompletableFuture.completedFuture(poLineCollection));
 
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(EDIFACT_PARSED_CONTENT));
+    ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfileWithPoLineSyntax);
+    addMockEntry(JOB_PROFILE_SNAPSHOTS_MOCK, profileSnapshotWrapper);
+
     HashMap<String, String> payloadContext = new HashMap<>();
     payloadContext.put(EDIFACT_INVOICE.value(), Json.encode(record));
-
-    ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfileWithPoLineSyntax);
+    payloadContext.put(JOB_PROFILE_SNAPSHOT_ID_KEY, profileSnapshotWrapper.getId());
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_EDIFACT_RECORD_CREATED.value())
       .withTenant(DI_POST_INVOICE_LINES_SUCCESS_TENANT)
       .withOkapiUrl(OKAPI_URL)
       .withToken(TOKEN)
-      .withContext(payloadContext)
-      .withProfileSnapshot(profileSnapshotWrapper);
+      .withContext(payloadContext);
 
     String topic = KafkaTopicNameHelper.formatTopicName(KAFKA_ENV_VALUE, getDefaultNameSpace(), DI_POST_INVOICE_LINES_SUCCESS_TENANT, dataImportEventPayload.getEventType());
-    Event event = new Event().withEventPayload(ZIPArchiver.zip(Json.encode(dataImportEventPayload)));
+    Event event = new Event().withEventPayload(Json.encode(dataImportEventPayload));
     KeyValue<String, String> kafkaRecord = new KeyValue<>("test-key", Json.encode(event));
     SendKeyValues<String, String> request = SendKeyValues.to(topic, Collections.singletonList(kafkaRecord))
       .useDefaults();
@@ -336,7 +340,7 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
       .build());
 
     Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
-    DataImportEventPayload eventPayload = Json.decodeValue(ZIPArchiver.unzip(obtainedEvent.getEventPayload()), DataImportEventPayload.class);
+    DataImportEventPayload eventPayload = Json.decodeValue(obtainedEvent.getEventPayload(), DataImportEventPayload.class);
     assertEquals(DI_INVOICE_CREATED.value(), eventPayload.getEventsChain().get(eventPayload.getEventsChain().size() -1));
 
     assertNotNull(eventPayload.getContext().get(INVOICE.value()));
@@ -369,21 +373,22 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
       .thenReturn(CompletableFuture.completedFuture(new PoLineCollection().withPoLines(List.of(poLine3))));
 
     ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfileWithPoLineSyntax);
+    addMockEntry(JOB_PROFILE_SNAPSHOTS_MOCK, profileSnapshotWrapper);
 
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(EDIFACT_PARSED_CONTENT));
     HashMap<String, String> payloadContext = new HashMap<>();
     payloadContext.put(EDIFACT_INVOICE.value(), Json.encode(record));
+    payloadContext.put(JOB_PROFILE_SNAPSHOT_ID_KEY, profileSnapshotWrapper.getId());
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_EDIFACT_RECORD_CREATED.value())
       .withTenant(DI_POST_INVOICE_LINES_SUCCESS_TENANT)
       .withOkapiUrl(OKAPI_URL)
       .withToken(TOKEN)
-      .withContext(payloadContext)
-      .withProfileSnapshot(profileSnapshotWrapper);
+      .withContext(payloadContext);
 
     String topic = KafkaTopicNameHelper.formatTopicName(KAFKA_ENV_VALUE, getDefaultNameSpace(), DI_POST_INVOICE_LINES_SUCCESS_TENANT, dataImportEventPayload.getEventType());
-    Event event = new Event().withEventPayload(ZIPArchiver.zip(Json.encode(dataImportEventPayload)));
+    Event event = new Event().withEventPayload(Json.encode(dataImportEventPayload));
     KeyValue<String, String> kafkaRecord = new KeyValue<>("test-key", Json.encode(event));
     SendKeyValues<String, String> request = SendKeyValues.to(topic, Collections.singletonList(kafkaRecord))
       .useDefaults();
@@ -399,7 +404,7 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
       .build());
 
     Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
-    DataImportEventPayload eventPayload = Json.decodeValue(ZIPArchiver.unzip(obtainedEvent.getEventPayload()), DataImportEventPayload.class);
+    DataImportEventPayload eventPayload = Json.decodeValue(obtainedEvent.getEventPayload(), DataImportEventPayload.class);
     assertEquals(DI_INVOICE_CREATED.value(), eventPayload.getEventsChain().get(eventPayload.getEventsChain().size() -1));
 
     assertNotNull(eventPayload.getContext().get(INVOICE.value()));
@@ -440,21 +445,22 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
       .thenReturn(CompletableFuture.completedFuture(poLineCollection));
 
     ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfileWithPoLineFundDistribution);
+    addMockEntry(JOB_PROFILE_SNAPSHOTS_MOCK, profileSnapshotWrapper);
 
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(EDIFACT_PARSED_CONTENT));
     HashMap<String, String> payloadContext = new HashMap<>();
     payloadContext.put(EDIFACT_INVOICE.value(), Json.encode(record));
+    payloadContext.put(JOB_PROFILE_SNAPSHOT_ID_KEY, profileSnapshotWrapper.getId());
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_EDIFACT_RECORD_CREATED.value())
       .withTenant(DI_POST_INVOICE_LINES_SUCCESS_TENANT)
       .withOkapiUrl(OKAPI_URL)
       .withToken(TOKEN)
-      .withContext(payloadContext)
-      .withProfileSnapshot(profileSnapshotWrapper);
+      .withContext(payloadContext);
 
     String topic = KafkaTopicNameHelper.formatTopicName(KAFKA_ENV_VALUE, getDefaultNameSpace(), DI_POST_INVOICE_LINES_SUCCESS_TENANT, dataImportEventPayload.getEventType());
-    Event event = new Event().withEventPayload(ZIPArchiver.zip(Json.encode(dataImportEventPayload)));
+    Event event = new Event().withEventPayload(Json.encode(dataImportEventPayload));
     KeyValue<String, String> kafkaRecord = new KeyValue<>("test-key", Json.encode(event));
     SendKeyValues<String, String> request = SendKeyValues.to(topic, Collections.singletonList(kafkaRecord))
       .useDefaults();
@@ -470,7 +476,7 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
       .build());
 
     Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
-    DataImportEventPayload eventPayload = Json.decodeValue(ZIPArchiver.unzip(obtainedEvent.getEventPayload()), DataImportEventPayload.class);
+    DataImportEventPayload eventPayload = Json.decodeValue(obtainedEvent.getEventPayload(), DataImportEventPayload.class);
     assertEquals(DI_INVOICE_CREATED.value(), eventPayload.getEventsChain().get(eventPayload.getEventsChain().size() -1));
 
     assertNotNull(eventPayload.getContext().get(INVOICE.value()));
@@ -503,21 +509,22 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
       .thenReturn(CompletableFuture.completedFuture(new PoLineCollection().withPoLines(List.of(poLine1, poLine3))));
 
     ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfileWithPoLineSyntax);
+    addMockEntry(JOB_PROFILE_SNAPSHOTS_MOCK, profileSnapshotWrapper);
 
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(EDIFACT_PARSED_CONTENT));
     HashMap<String, String> payloadContext = new HashMap<>();
     payloadContext.put(EDIFACT_INVOICE.value(), Json.encode(record));
+    payloadContext.put(JOB_PROFILE_SNAPSHOT_ID_KEY, profileSnapshotWrapper.getId());
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_EDIFACT_RECORD_CREATED.value())
       .withTenant(DI_POST_INVOICE_LINES_SUCCESS_TENANT)
       .withOkapiUrl(OKAPI_URL)
       .withToken(TOKEN)
-      .withContext(payloadContext)
-      .withProfileSnapshot(profileSnapshotWrapper);
+      .withContext(payloadContext);
 
     String topic = KafkaTopicNameHelper.formatTopicName(KAFKA_ENV_VALUE, getDefaultNameSpace(), DI_POST_INVOICE_LINES_SUCCESS_TENANT, dataImportEventPayload.getEventType());
-    Event event = new Event().withEventPayload(ZIPArchiver.zip(Json.encode(dataImportEventPayload)));
+    Event event = new Event().withEventPayload(Json.encode(dataImportEventPayload));
     KeyValue<String, String> kafkaRecord = new KeyValue<>("test-key", Json.encode(event));
     SendKeyValues<String, String> request = SendKeyValues.to(topic, Collections.singletonList(kafkaRecord))
       .useDefaults();
@@ -533,7 +540,7 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
       .build());
 
     Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
-    DataImportEventPayload eventPayload = Json.decodeValue(ZIPArchiver.unzip(obtainedEvent.getEventPayload()), DataImportEventPayload.class);
+    DataImportEventPayload eventPayload = Json.decodeValue(obtainedEvent.getEventPayload(), DataImportEventPayload.class);
     assertEquals(DI_INVOICE_CREATED.value(), eventPayload.getEventsChain().get(eventPayload.getEventsChain().size() -1));
 
     assertNotNull(eventPayload.getContext().get(INVOICE_LINES_KEY));
@@ -561,21 +568,22 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
       .thenReturn(CompletableFuture.completedFuture(new PoLineCollection()));
 
     ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfileWithMixedFundDistributionMapping);
+    addMockEntry(JOB_PROFILE_SNAPSHOTS_MOCK, profileSnapshotWrapper);
 
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(EDIFACT_PARSED_CONTENT));
     HashMap<String, String> payloadContext = new HashMap<>();
     payloadContext.put(EDIFACT_INVOICE.value(), Json.encode(record));
+    payloadContext.put(JOB_PROFILE_SNAPSHOT_ID_KEY, profileSnapshotWrapper.getId());
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_EDIFACT_RECORD_CREATED.value())
       .withTenant(DI_POST_INVOICE_LINES_SUCCESS_TENANT)
       .withOkapiUrl(OKAPI_URL)
       .withToken(TOKEN)
-      .withContext(payloadContext)
-      .withProfileSnapshot(profileSnapshotWrapper);
+      .withContext(payloadContext);
 
     String topic = KafkaTopicNameHelper.formatTopicName(KAFKA_ENV_VALUE, getDefaultNameSpace(), DI_POST_INVOICE_LINES_SUCCESS_TENANT, dataImportEventPayload.getEventType());
-    Event event = new Event().withEventPayload(ZIPArchiver.zip(Json.encode(dataImportEventPayload)));
+    Event event = new Event().withEventPayload(Json.encode(dataImportEventPayload));
     KeyValue<String, String> kafkaRecord = new KeyValue<>("test-key", Json.encode(event));
     SendKeyValues<String, String> request = SendKeyValues.to(topic, Collections.singletonList(kafkaRecord))
       .useDefaults();
@@ -591,7 +599,7 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
       .build());
 
     Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
-    DataImportEventPayload eventPayload = Json.decodeValue(ZIPArchiver.unzip(obtainedEvent.getEventPayload()), DataImportEventPayload.class);
+    DataImportEventPayload eventPayload = Json.decodeValue(obtainedEvent.getEventPayload(), DataImportEventPayload.class);
     assertEquals(DI_INVOICE_CREATED.value(), eventPayload.getEventsChain().get(eventPayload.getEventsChain().size() -1));
 
     assertNotNull(eventPayload.getContext().get(INVOICE.value()));
@@ -620,17 +628,19 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
   public void shouldPublishDiErrorEventWhenHasNoSourceRecord() throws IOException, InterruptedException {
     // given
     ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfile);
+    addMockEntry(JOB_PROFILE_SNAPSHOTS_MOCK, profileSnapshotWrapper);
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_EDIFACT_RECORD_CREATED.value())
       .withTenant(TENANT_ID)
       .withOkapiUrl(OKAPI_URL)
       .withToken(TOKEN)
-      .withContext(new HashMap<>())
-      .withProfileSnapshot(profileSnapshotWrapper);
+      .withContext(new HashMap<>() {{
+        put(JOB_PROFILE_SNAPSHOT_ID_KEY, profileSnapshotWrapper.getId());
+      }});
 
     String topic = KafkaTopicNameHelper.formatTopicName(KAFKA_ENV_VALUE, getDefaultNameSpace(), TENANT_ID, dataImportEventPayload.getEventType());
-    Event event = new Event().withEventPayload(ZIPArchiver.zip(Json.encode(dataImportEventPayload)));
+    Event event = new Event().withEventPayload(Json.encode(dataImportEventPayload));
     KeyValue<String, String> kafkaRecord = new KeyValue<>("test-key", Json.encode(event));
     SendKeyValues<String, String> request = SendKeyValues.to(topic, Collections.singletonList(kafkaRecord))
       .useDefaults();
@@ -646,7 +656,7 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
       .build());
 
     Event publishedEvent = Json.decodeValue(observedValues.get(0), Event.class);
-    DataImportEventPayload eventPayload = Json.decodeValue(ZIPArchiver.unzip(publishedEvent.getEventPayload()), DataImportEventPayload.class);
+    DataImportEventPayload eventPayload = Json.decodeValue(publishedEvent.getEventPayload(), DataImportEventPayload.class);
     assertEquals(DI_ERROR.value(), eventPayload.getEventType());
     assertEquals(DI_INVOICE_CREATED.value(), eventPayload.getEventsChain().get(eventPayload.getEventsChain().size() -1));
   }
@@ -655,20 +665,22 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
   public void shouldPublishDiErrorEventWhenPostInvoiceToStorageFailed() throws IOException, InterruptedException {
     // given
     ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfile);
+    addMockEntry(JOB_PROFILE_SNAPSHOTS_MOCK, profileSnapshotWrapper);
+
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(EDIFACT_PARSED_CONTENT));
     HashMap<String, String> payloadContext = new HashMap<>();
     payloadContext.put(EDIFACT_INVOICE.value(), Json.encode(record));
+    payloadContext.put(JOB_PROFILE_SNAPSHOT_ID_KEY, profileSnapshotWrapper.getId());
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_EDIFACT_RECORD_CREATED.value())
       .withTenant(ERROR_TENANT)
       .withOkapiUrl(OKAPI_URL)
       .withToken(TOKEN)
-      .withContext(payloadContext)
-      .withProfileSnapshot(profileSnapshotWrapper);
+      .withContext(payloadContext);
 
     String topic = KafkaTopicNameHelper.formatTopicName(KAFKA_ENV_VALUE, getDefaultNameSpace(), ERROR_TENANT, dataImportEventPayload.getEventType());
-    Event event = new Event().withEventPayload(ZIPArchiver.zip(Json.encode(dataImportEventPayload)));
+    Event event = new Event().withEventPayload(Json.encode(dataImportEventPayload));
     KeyValue<String, String> kafkaRecord = new KeyValue<>("test-key", Json.encode(event));
     SendKeyValues<String, String> request = SendKeyValues.to(topic, Collections.singletonList(kafkaRecord))
       .useDefaults();
@@ -684,7 +696,7 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
       .build());
 
     Event publishedEvent = Json.decodeValue(observedValues.get(0), Event.class);
-    DataImportEventPayload eventPayload = Json.decodeValue(ZIPArchiver.unzip(publishedEvent.getEventPayload()), DataImportEventPayload.class);
+    DataImportEventPayload eventPayload = Json.decodeValue(publishedEvent.getEventPayload(), DataImportEventPayload.class);
     assertEquals(DI_INVOICE_CREATED.value(), eventPayload.getEventsChain().get(eventPayload.getEventsChain().size() -1));
     assertNotNull(eventPayload.getContext().get(ERROR_MSG_KEY));
     assertNotNull(eventPayload.getContext().get(INVOICE.value()));
@@ -699,21 +711,22 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
   public void shouldPublishDiErrorWithInvoiceLineErrorWhenOneOfInvoiceLinesCreationFailed() throws IOException, InterruptedException {
     // given
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_INVOICE_LINE_3_HAS_NO_SUBTOTAL));
+    ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfile);
+    addMockEntry(JOB_PROFILE_SNAPSHOTS_MOCK, profileSnapshotWrapper);
+
     HashMap<String, String> payloadContext = new HashMap<>();
     payloadContext.put(EDIFACT_INVOICE.value(), Json.encode(record));
-
-    ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfile);
+    payloadContext.put(JOB_PROFILE_SNAPSHOT_ID_KEY, profileSnapshotWrapper.getId());
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_EDIFACT_RECORD_CREATED.value())
       .withTenant(DI_POST_INVOICE_LINES_SUCCESS_TENANT)
       .withOkapiUrl(OKAPI_URL)
       .withToken(TOKEN)
-      .withContext(payloadContext)
-      .withProfileSnapshot(profileSnapshotWrapper);
+      .withContext(payloadContext);
 
     String topic = KafkaTopicNameHelper.formatTopicName(KAFKA_ENV_VALUE, getDefaultNameSpace(), DI_POST_INVOICE_LINES_SUCCESS_TENANT, dataImportEventPayload.getEventType());
-    Event event = new Event().withEventPayload(ZIPArchiver.zip(Json.encode(dataImportEventPayload)));
+    Event event = new Event().withEventPayload(Json.encode(dataImportEventPayload));
     KeyValue<String, String> kafkaRecord = new KeyValue<>("test-key", Json.encode(event));
     SendKeyValues<String, String> request = SendKeyValues.to(topic, Collections.singletonList(kafkaRecord))
       .useDefaults();
@@ -730,7 +743,7 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
       .build());
 
     Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
-    DataImportEventPayload eventPayload = Json.decodeValue(ZIPArchiver.unzip(obtainedEvent.getEventPayload()), DataImportEventPayload.class);
+    DataImportEventPayload eventPayload = Json.decodeValue(obtainedEvent.getEventPayload(), DataImportEventPayload.class);
     assertEquals(DI_INVOICE_CREATED.value(), eventPayload.getEventsChain().get(eventPayload.getEventsChain().size() -1));
 
     assertNotNull(eventPayload.getContext().get(INVOICE.value()));
@@ -754,21 +767,22 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
   public void shouldPublishDiErrorWhenMappingProfileHasInvalidMappingSyntax() throws IOException, InterruptedException {
     // given
     Record record = new Record().withParsedRecord(new ParsedRecord().withContent(PARSED_CONTENT_INVOICE_LINE_3_HAS_NO_SUBTOTAL));
+    ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfileWithInvalidMappingSyntax);
+    addMockEntry(JOB_PROFILE_SNAPSHOTS_MOCK, profileSnapshotWrapper);
+
     HashMap<String, String> payloadContext = new HashMap<>();
     payloadContext.put(EDIFACT_INVOICE.value(), Json.encode(record));
-
-    ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfileWithInvalidMappingSyntax);
+    payloadContext.put(JOB_PROFILE_SNAPSHOT_ID_KEY, profileSnapshotWrapper.getId());
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_EDIFACT_RECORD_CREATED.value())
       .withTenant(DI_POST_INVOICE_LINES_SUCCESS_TENANT)
       .withOkapiUrl(OKAPI_URL)
       .withToken(TOKEN)
-      .withContext(payloadContext)
-      .withProfileSnapshot(profileSnapshotWrapper);
+      .withContext(payloadContext);
 
     String topic = KafkaTopicNameHelper.formatTopicName(KAFKA_ENV_VALUE, getDefaultNameSpace(), DI_POST_INVOICE_LINES_SUCCESS_TENANT, dataImportEventPayload.getEventType());
-    Event event = new Event().withEventPayload(ZIPArchiver.zip(Json.encode(dataImportEventPayload)));
+    Event event = new Event().withEventPayload(Json.encode(dataImportEventPayload));
     KeyValue<String, String> kafkaRecord = new KeyValue<>("test-key", Json.encode(event));
     SendKeyValues<String, String> request = SendKeyValues.to(topic, Collections.singletonList(kafkaRecord))
       .useDefaults();
@@ -785,7 +799,7 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
       .build());
 
     Event obtainedEvent = Json.decodeValue(observedValues.get(0), Event.class);
-    DataImportEventPayload eventPayload = Json.decodeValue(ZIPArchiver.unzip(obtainedEvent.getEventPayload()), DataImportEventPayload.class);
+    DataImportEventPayload eventPayload = Json.decodeValue(obtainedEvent.getEventPayload(), DataImportEventPayload.class);
     assertEquals(DI_INVOICE_CREATED.value(), eventPayload.getEventsChain().get(eventPayload.getEventsChain().size() -1));
   }
 
@@ -795,7 +809,6 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
     ProfileSnapshotWrapper profileSnapshotWrapper = buildProfileSnapshotWrapper(jobProfile, actionProfile, mappingProfile);
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_EDIFACT_RECORD_CREATED.value())
-      .withProfileSnapshot(profileSnapshotWrapper)
       .withCurrentNode(profileSnapshotWrapper.getChildSnapshotWrappers().get(0));
 
     // when
@@ -822,7 +835,6 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_EDIFACT_RECORD_CREATED.value())
-      .withProfileSnapshot(profileSnapshotWrapper)
       .withCurrentNode(profileSnapshotWrapper);
 
     // when


### PR DESCRIPTION
## Purpose
to reduce event payload size by removing jobProfileSnapshot

## Approach
* fetch jobProfileSnapshot on demand and cache it for subsequent usage
* remove all zipping/unzipping operations for data-import payload
* update tests

## Learning
[MODINVOICE-259](https://issues.folio.org/browse/MODINVOICE-259)
should be merged after https://github.com/folio-org/data-import-processing-core/pull/166