### PR TITLE
Update folio-kafka-wrapper to 2.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.4.0-SNAPSHOT</version>
+      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>


### PR DESCRIPTION
folio-kafka-wrapper v2.4.0 was released, the development version 2.4.0-SNAPSHOT is no longer relevant and will be deleted from nexus repository

