### PR TITLE
MODINVOICE-306. Acq unit in invoice field mapping profile causes import to complete with errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 5.2.0 - Unrleased
 * [MODINVOICE-251](https://issues.folio.org/browse/MODINVOICE-251) - Remove zipping mechanism for data-import event payloads and use cache for job profile snapshot
+* [MODINVOICE-306](https://issues.folio.org/browse/MODINVOICE-306) - Acq unit in invoice field mapping profile causes import to complete with errors
 
 ## 5.1.0 - Released
 

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>3.2.0</version>
+      <version>3.3.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/src/main/java/org/folio/dataimport/handlers/events/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/dataimport/handlers/events/DataImportKafkaHandler.java
@@ -1,13 +1,21 @@
 package org.folio.dataimport.handlers.events;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.Json;
+import io.vertx.kafka.client.producer.KafkaHeader;
+import org.apache.commons.collections4.CollectionUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.DataImportEventPayload;
+import org.folio.dataimport.utils.DataImportUtils;
 import org.folio.dataimport.InvoiceWriterFactory;
 import org.folio.dataimport.cache.JobProfileSnapshotCache;
 import org.folio.dataimport.handlers.actions.CreateInvoiceEventHandler;
@@ -16,14 +24,12 @@ import org.folio.processing.events.EventManager;
 import org.folio.processing.exceptions.EventProcessingException;
 import org.folio.processing.mapping.MappingManager;
 import org.folio.processing.mapping.mapper.reader.record.edifact.EdifactReaderFactory;
-import org.folio.rest.RestConstants;
-import org.folio.rest.RestVerticle;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.jaxrs.model.Event;
+import org.folio.utils.UserPermissionsUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -55,9 +61,10 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
       Event event = DatabindCodec.mapper().readValue(kafkaRecord.value(), Event.class);
       DataImportEventPayload eventPayload = Json.decodeValue(event.getEventPayload(), DataImportEventPayload.class);
       logger.info("Data import event payload has been received with event type: {}", eventPayload.getEventType());
+      populateContextWithOkapiPermissions(kafkaRecord, eventPayload);
 
       String profileSnapshotId = eventPayload.getContext().get(JOB_PROFILE_SNAPSHOT_ID_KEY);
-      Map<String, String> okapiHeaders = retrieveOkapiHeaders(eventPayload);
+      Map<String, String> okapiHeaders = DataImportUtils.getOkapiHeaders(eventPayload);
 
       profileSnapshotCache.get(profileSnapshotId, okapiHeaders)
         .thenCompose(snapshotOptional -> snapshotOptional
@@ -79,9 +86,16 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
     }
   }
 
-  private Map<String, String> retrieveOkapiHeaders(DataImportEventPayload eventPayload) {
-    return Map.of(RestConstants.OKAPI_URL, eventPayload.getOkapiUrl(),
-      RestVerticle.OKAPI_HEADER_TENANT, eventPayload.getTenant(),
-      RestVerticle.OKAPI_HEADER_TOKEN, eventPayload.getToken());
+  private void populateContextWithOkapiPermissions(KafkaConsumerRecord<String, String> kafkaRecord,
+                                                   DataImportEventPayload eventPayload) {
+    List<KafkaHeader> headers = kafkaRecord.headers();
+    if (CollectionUtils.isNotEmpty(headers)) {
+      List<String> permissions = headers.stream()
+        .filter(header -> UserPermissionsUtil.OKAPI_HEADER_PERMISSIONS.equalsIgnoreCase(header.key()))
+        .map(KafkaHeader::value)
+        .map(Buffer::toString)
+        .collect(Collectors.toList());
+      eventPayload.getContext().put(DataImportUtils.DATA_IMPORT_PAYLOAD_OKAPI_PERMISSIONS, Json.encode(permissions));
+    }
   }
 }

--- a/src/main/java/org/folio/dataimport/handlers/events/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/dataimport/handlers/events/DataImportKafkaHandler.java
@@ -88,13 +88,12 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
 
   private void populateContextWithOkapiPermissions(KafkaConsumerRecord<String, String> kafkaRecord,
                                                    DataImportEventPayload eventPayload) {
-    List<KafkaHeader> headers = kafkaRecord.headers();
-    if (CollectionUtils.isNotEmpty(headers)) {
-      List<String> permissions = headers.stream()
-        .filter(header -> UserPermissionsUtil.OKAPI_HEADER_PERMISSIONS.equalsIgnoreCase(header.key()))
-        .map(KafkaHeader::value)
-        .map(Buffer::toString)
-        .collect(Collectors.toList());
+    List<String> permissions = kafkaRecord.headers().stream()
+      .filter(header -> UserPermissionsUtil.OKAPI_HEADER_PERMISSIONS.equalsIgnoreCase(header.key()))
+      .map(KafkaHeader::value)
+      .map(Buffer::toString)
+      .collect(Collectors.toList());
+    if (CollectionUtils.isNotEmpty(permissions)) {
       eventPayload.getContext().put(DataImportUtils.DATA_IMPORT_PAYLOAD_OKAPI_PERMISSIONS, Json.encode(permissions));
     }
   }

--- a/src/main/java/org/folio/dataimport/handlers/events/DataImportKafkaHandler.java
+++ b/src/main/java/org/folio/dataimport/handlers/events/DataImportKafkaHandler.java
@@ -1,13 +1,9 @@
 package org.folio.dataimport.handlers.events;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
 
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.Json;
 import io.vertx.kafka.client.producer.KafkaHeader;
-import org.apache.commons.collections4.CollectionUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.jackson.DatabindCodec;
@@ -62,7 +58,7 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
       Event event = DatabindCodec.mapper().readValue(kafkaRecord.value(), Event.class);
       DataImportEventPayload eventPayload = Json.decodeValue(event.getEventPayload(), DataImportEventPayload.class);
       logger.info("Data import event payload has been received with event type: {}", eventPayload.getEventType());
-      populateContextWithOkapiPermissions(kafkaRecord, eventPayload);
+      populateContextWithOkapiUserAndPerms(kafkaRecord, eventPayload);
 
       String profileSnapshotId = eventPayload.getContext().get(JOB_PROFILE_SNAPSHOT_ID_KEY);
       Map<String, String> okapiHeaders = DataImportUtils.getOkapiHeaders(eventPayload);
@@ -87,8 +83,8 @@ public class DataImportKafkaHandler implements AsyncRecordHandler<String, String
     }
   }
 
-  private void populateContextWithOkapiPermissions(KafkaConsumerRecord<String, String> kafkaRecord,
-                                                   DataImportEventPayload eventPayload) {
+  private void populateContextWithOkapiUserAndPerms(KafkaConsumerRecord<String, String> kafkaRecord,
+                                                    DataImportEventPayload eventPayload) {
     for (KafkaHeader header: kafkaRecord.headers()) {
       if (UserPermissionsUtil.OKAPI_HEADER_PERMISSIONS.equalsIgnoreCase(header.key())) {
         String permissions = header.value().toString();

--- a/src/main/java/org/folio/dataimport/utils/DataImportUtils.java
+++ b/src/main/java/org/folio/dataimport/utils/DataImportUtils.java
@@ -6,6 +6,7 @@ import org.folio.rest.RestConstants;
 import org.folio.rest.RestVerticle;
 import org.folio.utils.UserPermissionsUtil;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,6 +25,6 @@ public class DataImportUtils {
     if (StringUtils.isNotBlank(payloadPermissions)) {
       result.put(UserPermissionsUtil.OKAPI_HEADER_PERMISSIONS, payloadPermissions);
     }
-    return result;
+    return Collections.unmodifiableMap(result);
   }
 }

--- a/src/main/java/org/folio/dataimport/utils/DataImportUtils.java
+++ b/src/main/java/org/folio/dataimport/utils/DataImportUtils.java
@@ -1,0 +1,29 @@
+package org.folio.dataimport.utils;
+
+import org.apache.commons.lang3.StringUtils;
+import org.folio.DataImportEventPayload;
+import org.folio.rest.RestConstants;
+import org.folio.rest.RestVerticle;
+import org.folio.utils.UserPermissionsUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DataImportUtils {
+  public static final String DATA_IMPORT_PAYLOAD_OKAPI_PERMISSIONS = "data-import-payload-okapi-permissions";
+
+  private DataImportUtils() {}
+
+  public static Map<String, String> getOkapiHeaders(DataImportEventPayload eventPayload) {
+    Map<String, String> result = new HashMap<>();
+    result.put(RestVerticle.OKAPI_HEADER_TENANT, eventPayload.getTenant());
+    result.put(RestVerticle.OKAPI_HEADER_TOKEN, eventPayload.getToken());
+    result.put(RestConstants.OKAPI_URL, eventPayload.getOkapiUrl());
+
+    String payloadPermissions = eventPayload.getContext().get(DATA_IMPORT_PAYLOAD_OKAPI_PERMISSIONS);
+    if (StringUtils.isNotBlank(payloadPermissions)) {
+      result.put(UserPermissionsUtil.OKAPI_HEADER_PERMISSIONS, payloadPermissions);
+    }
+    return result;
+  }
+}

--- a/src/main/java/org/folio/dataimport/utils/DataImportUtils.java
+++ b/src/main/java/org/folio/dataimport/utils/DataImportUtils.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 public class DataImportUtils {
   public static final String DATA_IMPORT_PAYLOAD_OKAPI_PERMISSIONS = "data-import-payload-okapi-permissions";
+  public static final String DATA_IMPORT_PAYLOAD_OKAPI_USER_ID = "data-import-payload-okapi-user-id";
 
   private DataImportUtils() {}
 
@@ -24,6 +25,10 @@ public class DataImportUtils {
     String payloadPermissions = eventPayload.getContext().get(DATA_IMPORT_PAYLOAD_OKAPI_PERMISSIONS);
     if (StringUtils.isNotBlank(payloadPermissions)) {
       result.put(UserPermissionsUtil.OKAPI_HEADER_PERMISSIONS, payloadPermissions);
+    }
+    String userId = eventPayload.getContext().get(DATA_IMPORT_PAYLOAD_OKAPI_USER_ID);
+    if (StringUtils.isNotBlank(userId)) {
+      result.put(RestVerticle.OKAPI_USERID_HEADER, userId);
     }
     return Collections.unmodifiableMap(result);
   }

--- a/src/test/java/org/folio/dataimport/handlers/actions/CreateInvoiceEventHandlerTest.java
+++ b/src/test/java/org/folio/dataimport/handlers/actions/CreateInvoiceEventHandlerTest.java
@@ -55,6 +55,7 @@ import static org.folio.DataImportEventTypes.DI_INVOICE_CREATED;
 import static org.folio.dataimport.handlers.actions.CreateInvoiceEventHandler.INVOICE_LINES_ERRORS_KEY;
 import static org.folio.dataimport.handlers.actions.CreateInvoiceEventHandler.INVOICE_LINES_KEY;
 import static org.folio.dataimport.utils.DataImportUtils.DATA_IMPORT_PAYLOAD_OKAPI_PERMISSIONS;
+import static org.folio.dataimport.utils.DataImportUtils.DATA_IMPORT_PAYLOAD_OKAPI_USER_ID;
 import static org.folio.kafka.KafkaTopicNameHelper.getDefaultNameSpace;
 import static org.folio.rest.impl.MockServer.DI_POST_INVOICE_LINES_SUCCESS_TENANT;
 import static org.folio.rest.impl.MockServer.ERROR_TENANT;
@@ -93,7 +94,8 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
   private static final String GROUP_ID = "test-consumers-group";
   private static final String JOB_PROFILE_SNAPSHOTS_MOCK = "jobProfileSnapshots";
   private static final String JOB_PROFILE_SNAPSHOT_ID_KEY = "JOB_PROFILE_SNAPSHOT_ID";
-  public static final String ERROR_MSG_KEY = "ERROR";
+  private static final String ERROR_MSG_KEY = "ERROR";
+  private static final String USER_ID = "userId";
 
   private JobProfile jobProfile = new JobProfile()
     .withId(UUID.randomUUID().toString())
@@ -314,6 +316,7 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
     payloadContext.put(EDIFACT_INVOICE.value(), Json.encode(record));
     payloadContext.put(JOB_PROFILE_SNAPSHOT_ID_KEY, profileSnapshotWrapper.getId());
     payloadContext.put(DATA_IMPORT_PAYLOAD_OKAPI_PERMISSIONS, Json.encode(Collections.singletonList(AcqDesiredPermissions.ASSIGN.getPermission())));
+    payloadContext.put(DATA_IMPORT_PAYLOAD_OKAPI_USER_ID, USER_ID);
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_EDIFACT_RECORD_CREATED.value())

--- a/src/test/java/org/folio/dataimport/handlers/actions/CreateInvoiceEventHandlerTest.java
+++ b/src/test/java/org/folio/dataimport/handlers/actions/CreateInvoiceEventHandlerTest.java
@@ -17,6 +17,7 @@ import org.folio.JobProfile;
 import org.folio.MappingProfile;
 import org.folio.ParsedRecord;
 import org.folio.Record;
+import org.folio.invoices.utils.AcqDesiredPermissions;
 import org.folio.kafka.KafkaTopicNameHelper;
 import org.folio.processing.events.EventManager;
 import org.folio.processing.events.services.handler.EventHandler;
@@ -40,11 +41,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -57,6 +54,7 @@ import static org.folio.DataImportEventTypes.DI_ERROR;
 import static org.folio.DataImportEventTypes.DI_INVOICE_CREATED;
 import static org.folio.dataimport.handlers.actions.CreateInvoiceEventHandler.INVOICE_LINES_ERRORS_KEY;
 import static org.folio.dataimport.handlers.actions.CreateInvoiceEventHandler.INVOICE_LINES_KEY;
+import static org.folio.dataimport.utils.DataImportUtils.DATA_IMPORT_PAYLOAD_OKAPI_PERMISSIONS;
 import static org.folio.kafka.KafkaTopicNameHelper.getDefaultNameSpace;
 import static org.folio.rest.impl.MockServer.DI_POST_INVOICE_LINES_SUCCESS_TENANT;
 import static org.folio.rest.impl.MockServer.ERROR_TENANT;
@@ -315,6 +313,7 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
     HashMap<String, String> payloadContext = new HashMap<>();
     payloadContext.put(EDIFACT_INVOICE.value(), Json.encode(record));
     payloadContext.put(JOB_PROFILE_SNAPSHOT_ID_KEY, profileSnapshotWrapper.getId());
+    payloadContext.put(DATA_IMPORT_PAYLOAD_OKAPI_PERMISSIONS, Json.encode(Collections.singletonList(AcqDesiredPermissions.ASSIGN.getPermission())));
 
     DataImportEventPayload dataImportEventPayload = new DataImportEventPayload()
       .withEventType(DI_EDIFACT_RECORD_CREATED.value())

--- a/src/test/java/org/folio/dataimport/utils/DataImportUtilsTest.java
+++ b/src/test/java/org/folio/dataimport/utils/DataImportUtilsTest.java
@@ -17,7 +17,8 @@ public class DataImportUtilsTest {
   private static final String TENANT = "diku";
   private static final String TOKEN = "token";
   private static final String OKAPI_URL = "okapi_url";
-  public static final String PERMISSIONS_ARRAY = "[\"invoices.acquisitions-units-assignments.assign\"]";
+  private static final String PERMISSIONS_ARRAY = "[\"invoices.acquisitions-units-assignments.assign\"]";
+  private static final String USER_ID = "userId";
 
   @Test
   public void shouldNotReturnOkapiPermissionsIfNotExistsInContext() {
@@ -32,18 +33,20 @@ public class DataImportUtilsTest {
   }
 
   @Test
-  public void shouldAlsoReturnOkapiPermissionsIfExistsInContext() {
+  public void shouldAlsoReturnOkapiPermissionsAndUserIdIfExistsInContext() {
     HashMap<String, String> context = new HashMap<>();
     context.put(DataImportUtils.DATA_IMPORT_PAYLOAD_OKAPI_PERMISSIONS, PERMISSIONS_ARRAY);
+    context.put(DataImportUtils.DATA_IMPORT_PAYLOAD_OKAPI_USER_ID, USER_ID);
     DataImportEventPayload payload = getPayload(context);
 
     Map<String, String> okapiHeaders = DataImportUtils.getOkapiHeaders(payload);
 
-    assertEquals(4, okapiHeaders.size());
+    assertEquals(5, okapiHeaders.size());
     assertEquals(TENANT, okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT));
     assertEquals(TOKEN, okapiHeaders.get(RestVerticle.OKAPI_HEADER_TOKEN));
     assertEquals(OKAPI_URL, okapiHeaders.get(RestConstants.OKAPI_URL));
     assertEquals(PERMISSIONS_ARRAY, okapiHeaders.get(UserPermissionsUtil.OKAPI_HEADER_PERMISSIONS));
+    assertEquals(USER_ID, okapiHeaders.get(RestVerticle.OKAPI_USERID_HEADER));
   }
 
   private DataImportEventPayload getPayload(HashMap<String, String> context) {

--- a/src/test/java/org/folio/dataimport/utils/DataImportUtilsTest.java
+++ b/src/test/java/org/folio/dataimport/utils/DataImportUtilsTest.java
@@ -33,7 +33,37 @@ public class DataImportUtilsTest {
   }
 
   @Test
-  public void shouldAlsoReturnOkapiPermissionsAndUserIdIfExistsInContext() {
+  public void shouldAlsoReturnOkapiPermissionsIfExistsInContext() {
+    HashMap<String, String> context = new HashMap<>();
+    context.put(DataImportUtils.DATA_IMPORT_PAYLOAD_OKAPI_PERMISSIONS, PERMISSIONS_ARRAY);
+    DataImportEventPayload payload = getPayload(context);
+
+    Map<String, String> okapiHeaders = DataImportUtils.getOkapiHeaders(payload);
+
+    assertEquals(4, okapiHeaders.size());
+    assertEquals(TENANT, okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT));
+    assertEquals(TOKEN, okapiHeaders.get(RestVerticle.OKAPI_HEADER_TOKEN));
+    assertEquals(OKAPI_URL, okapiHeaders.get(RestConstants.OKAPI_URL));
+    assertEquals(PERMISSIONS_ARRAY, okapiHeaders.get(UserPermissionsUtil.OKAPI_HEADER_PERMISSIONS));
+  }
+
+  @Test
+  public void shouldAlsoReturnUserIdIfExistsInContext() {
+    HashMap<String, String> context = new HashMap<>();
+    context.put(DataImportUtils.DATA_IMPORT_PAYLOAD_OKAPI_USER_ID, USER_ID);
+    DataImportEventPayload payload = getPayload(context);
+
+    Map<String, String> okapiHeaders = DataImportUtils.getOkapiHeaders(payload);
+
+    assertEquals(4, okapiHeaders.size());
+    assertEquals(TENANT, okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT));
+    assertEquals(TOKEN, okapiHeaders.get(RestVerticle.OKAPI_HEADER_TOKEN));
+    assertEquals(OKAPI_URL, okapiHeaders.get(RestConstants.OKAPI_URL));
+    assertEquals(USER_ID, okapiHeaders.get(RestVerticle.OKAPI_USERID_HEADER));
+  }
+
+  @Test
+  public void shouldReturlAllPossibleAuthValues() {
     HashMap<String, String> context = new HashMap<>();
     context.put(DataImportUtils.DATA_IMPORT_PAYLOAD_OKAPI_PERMISSIONS, PERMISSIONS_ARRAY);
     context.put(DataImportUtils.DATA_IMPORT_PAYLOAD_OKAPI_USER_ID, USER_ID);

--- a/src/test/java/org/folio/dataimport/utils/DataImportUtilsTest.java
+++ b/src/test/java/org/folio/dataimport/utils/DataImportUtilsTest.java
@@ -1,0 +1,57 @@
+package org.folio.dataimport.utils;
+
+import com.google.common.collect.Maps;
+import org.folio.DataImportEventPayload;
+import org.folio.rest.RestConstants;
+import org.folio.rest.RestVerticle;
+import org.folio.utils.UserPermissionsUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DataImportUtilsTest {
+
+  private static final String TENANT = "diku";
+  private static final String TOKEN = "token";
+  private static final String OKAPI_URL = "okapi_url";
+  public static final String PERMISSIONS_ARRAY = "[\"invoices.acquisitions-units-assignments.assign\"]";
+
+  @Test
+  public void shouldNotReturnOkapiPermissionsIfNotExistsInContext() {
+    DataImportEventPayload payload = getPayload(Maps.newHashMap());
+
+    Map<String, String> okapiHeaders = DataImportUtils.getOkapiHeaders(payload);
+
+    assertEquals(3, okapiHeaders.size());
+    assertEquals(TENANT, okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT));
+    assertEquals(TOKEN, okapiHeaders.get(RestVerticle.OKAPI_HEADER_TOKEN));
+    assertEquals(OKAPI_URL, okapiHeaders.get(RestConstants.OKAPI_URL));
+  }
+
+  @Test
+  public void shouldAlsoReturnOkapiPermissionsIfExistsInContext() {
+    HashMap<String, String> context = new HashMap<>();
+    context.put(DataImportUtils.DATA_IMPORT_PAYLOAD_OKAPI_PERMISSIONS, PERMISSIONS_ARRAY);
+    DataImportEventPayload payload = getPayload(context);
+
+    Map<String, String> okapiHeaders = DataImportUtils.getOkapiHeaders(payload);
+
+    assertEquals(4, okapiHeaders.size());
+    assertEquals(TENANT, okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT));
+    assertEquals(TOKEN, okapiHeaders.get(RestVerticle.OKAPI_HEADER_TOKEN));
+    assertEquals(OKAPI_URL, okapiHeaders.get(RestConstants.OKAPI_URL));
+    assertEquals(PERMISSIONS_ARRAY, okapiHeaders.get(UserPermissionsUtil.OKAPI_HEADER_PERMISSIONS));
+  }
+
+  private DataImportEventPayload getPayload(HashMap<String, String> context) {
+    DataImportEventPayload payload = new DataImportEventPayload();
+    payload.setTenant(TENANT);
+    payload.setToken(TOKEN);
+    payload.setOkapiUrl(OKAPI_URL);
+    payload.setContext(context);
+    return payload;
+  }
+}


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODINVOICE-306

## Approach
To resolve this issue it was necessary changes in 3 modules:
- Need to add necessary permission in mod-data-import. Corresponding PR: https://github.com/folio-org/mod-data-import/pull/198
- Current PR in mod-invoice, in scope of each it was necessary to change logic for retrieving Okapi permissions, because without these changes recently added desired permission in mod-data-import is not visible for mod-invoice processing. Also it was fixed issue connected with calling acquisition-units endpoint when providing language as null
- Its needed changes in data-import-processing-core. Corresponding PR was merged: https://github.com/folio-org/data-import-processing-core/pull/176/files. The issue connected with invoice mapping in data-import-processing-core. Currently instead of acquisition ids data-import-processing-core returns acquisition names that is a reason of failure validation in mod-invoice
