### PR TITLE
MODDICORE-199 - Add EDIFACT mapping syntax for multiple fields mapping into 1 invoice field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>3.2.2</version>
+      <version>3.3.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>


### PR DESCRIPTION
## Purpose
update di-core library version to provide support of mapping syntax for multiple EDIFACT fields for invoice mapping.


## Learning
[MODDICORE-199](https://issues.folio.org/browse/MODDICORE-199)
