### PR TITLE
MODINVOICE-356. Fix progress bar stuck behaviour after the RecordTooLargeException

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 5.3.0 - Unreleased
+* [MODINVOICE-356](https://issues.folio.org/browse/MODINVOICE-356) - Fix progress bar stuck behaviour after the RecordTooLargeException
 
 ## 5.2.1 - Unreleased
 * [MODINVOICE-314](https://issues.folio.org/browse/MODINVOICE-314) - Provide recordId header for data-import events correlation

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.4.0</version>
+      <version>2.5.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/src/test/java/org/folio/dataimport/handlers/actions/CreateInvoiceEventHandlerTest.java
+++ b/src/test/java/org/folio/dataimport/handlers/actions/CreateInvoiceEventHandlerTest.java
@@ -298,6 +298,11 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
     assertEquals("Open", createdInvoice.getStatus().value());
     assertEquals(Invoice.Source.EDI, createdInvoice.getSource());
 
+    assertNotNull(eventPayload.getContext().get(EDIFACT_INVOICE.value()));
+    Record sourceRecord = Json.decodeValue(eventPayload.getContext().get(EDIFACT_INVOICE.value()), Record.class);
+    assertNull(sourceRecord.getParsedRecord());
+    assertNull(sourceRecord.getRawRecord());
+
     assertNotNull(eventPayload.getContext().get(INVOICE_LINES_KEY));
     InvoiceLineCollection createdInvoiceLines = Json.decodeValue(eventPayload.getContext().get(INVOICE_LINES_KEY), InvoiceLineCollection.class);
     assertEquals(3, createdInvoiceLines.getTotalRecords());
@@ -720,6 +725,11 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
     assertNotNull(eventPayload.getContext().get(ERROR_MSG_KEY));
     assertNotNull(eventPayload.getContext().get(INVOICE.value()));
     assertNotNull(eventPayload.getContext().get(INVOICE_LINES_KEY));
+
+    assertNotNull(eventPayload.getContext().get(EDIFACT_INVOICE.value()));
+    Record sourceRecord = Json.decodeValue(eventPayload.getContext().get(EDIFACT_INVOICE.value()), Record.class);
+    assertNull(sourceRecord.getParsedRecord());
+    assertNull(sourceRecord.getRawRecord());
 
     InvoiceLineCollection invoiceLineCollection = Json.decodeValue(eventPayload.getContext().get(INVOICE_LINES_KEY), InvoiceLineCollection.class);
     assertEquals(3, invoiceLineCollection.getTotalRecords());


### PR DESCRIPTION
At the original issue configuration MAX_REQUEST_FILE on SRM was 4mb, on SRS 4mb, on mod-invoice 1mb.

File that was mentioned in issue successfully processed, all invoice lines created, but during sending DI_COMPLETE RecordTooLargeException occured.
During investigation it was found that most of size allocated for parsed record object(not invoice lines object) and it is optional for sending back to SRM, but removing this property allows to reduсe payload in 6 times (comparing with size of invoice lines object)

Get parsed record size: 1,241,626 bytes
Get raw record size: 159,021 bytes
Invoice lines size: 233,288 bytes
