### PR TITLE
Adjust default max_request_size value for kafka messages

### DIFF
--- a/src/main/java/org/folio/config/KafkaConsumersConfiguration.java
+++ b/src/main/java/org/folio/config/KafkaConsumersConfiguration.java
@@ -14,7 +14,7 @@ public class KafkaConsumersConfiguration {
   private String okapiUrl;
   @Value("${REPLICATION_FACTOR:1}")
   private int replicationFactor;
-  @Value("${MAX_REQUEST_SIZE:1048576}")
+  @Value("${MAX_REQUEST_SIZE:4000000}")
   private int maxRequestSize;
   @Value("${ENV:folio}")
   private String envId;


### PR DESCRIPTION
Even though Kafka message payload was significantly decreased, it is still recommended to adjust MAX_REQUEST_SIZE value to allow importing large files. Setting default value to 4000000 bytes would make adjustment of that property unnecessary.