### PR TITLE
[MODINVOICE-328] Removed subscription dates and info from protected fields

### DIFF
--- a/src/main/java/org/folio/invoices/utils/InvoiceLineProtectedFields.java
+++ b/src/main/java/org/folio/invoices/utils/InvoiceLineProtectedFields.java
@@ -15,9 +15,6 @@ public enum InvoiceLineProtectedFields {
   PRODUCT_ID("productId"),
   PRODUCT_ID_TYPE("productIdType"),
   QUANTITY("quantity"),
-  SUBSCRIPTION_INFO("subscriptionInfo"),
-  SUBSCRIPTION_START("subscriptionStart"),
-  SUBSCRIPTION_END("subscriptionEnd"),
   SUB_TOTAL("subTotal"),
   TOTAL("total");
 

--- a/src/test/java/org/folio/rest/impl/InvoiceLinesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoiceLinesApiTest.java
@@ -662,9 +662,6 @@ public class InvoiceLinesApiTest extends ApiTestBase {
     allProtectedFieldsModification.put(InvoiceLineProtectedFields.PRODUCT_ID, UUID.randomUUID().toString());
     allProtectedFieldsModification.put(InvoiceLineProtectedFields.PRODUCT_ID_TYPE, UUID.randomUUID().toString());
     allProtectedFieldsModification.put(InvoiceLineProtectedFields.QUANTITY, 10);
-    allProtectedFieldsModification.put(InvoiceLineProtectedFields.SUBSCRIPTION_INFO, "Tested subscription info");
-    allProtectedFieldsModification.put(InvoiceLineProtectedFields.SUBSCRIPTION_START, new Date(System.currentTimeMillis()));
-    allProtectedFieldsModification.put(InvoiceLineProtectedFields.SUBSCRIPTION_END, new Date(System.currentTimeMillis()));
 
     checkPreventInvoiceLineModificationRule(allProtectedFieldsModifiedInvoiceLine, allProtectedFieldsModification);
 


### PR DESCRIPTION
## Purpose
[MODINVOICE-328](https://issues.folio.org/browse/MODINVOICE-328) - Allow editing of subscription dates after an invoice is paid

## Approach
- Removed the fields from InvoiceLineProtectedFields
- Updated test

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
