### PR TITLE
[MODINVOICE-463] Using invoice FY to find budgets to approve/pay

### DIFF
--- a/src/main/java/org/folio/InvoiceWorkflowDataHolderBuilder.java
+++ b/src/main/java/org/folio/InvoiceWorkflowDataHolderBuilder.java
@@ -113,7 +113,7 @@ public class InvoiceWorkflowDataHolderBuilder {
   }
 
   public Future<List<InvoiceWorkflowDataHolder>> withBudgets(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
-    if (holders.size() == 0)
+    if (holders.isEmpty())
       return succeededFuture(holders);
     List<String> fundIds = holders.stream().map(InvoiceWorkflowDataHolder::getFundId).distinct().collect(toList());
     String invoiceFiscalYearId = holders.get(0).getInvoice().getFiscalYearId();
@@ -142,7 +142,7 @@ public class InvoiceWorkflowDataHolderBuilder {
   }
 
   public Future<List<InvoiceWorkflowDataHolder>> withFiscalYear(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
-    if (holders.size() == 0)
+    if (holders.isEmpty())
       return succeededFuture(holders);
     String fiscalYearId = holders.get(0).getBudget().getFiscalYearId();
     return fiscalYearService.getFiscalYear(fiscalYearId, requestContext)

--- a/src/main/java/org/folio/InvoiceWorkflowDataHolderBuilder.java
+++ b/src/main/java/org/folio/InvoiceWorkflowDataHolderBuilder.java
@@ -46,79 +46,83 @@ import io.vertx.core.Future;
 
 public class InvoiceWorkflowDataHolderBuilder {
 
-    private static final Logger log = LogManager.getLogger(InvoiceWorkflowDataHolderBuilder.class);
+  private static final Logger log = LogManager.getLogger(InvoiceWorkflowDataHolderBuilder.class);
 
-    private final ExchangeRateProviderResolver exchangeRateProviderResolver;
-    private final FiscalYearService fiscalYearService;
-    private final FundService fundService;
-    private final LedgerService ledgerService;
-    private final BaseTransactionService baseTransactionService;
-    private final BudgetService budgetService;
-    private final ExpenseClassRetrieveService expenseClassRetrieveService;
+  private final ExchangeRateProviderResolver exchangeRateProviderResolver;
+  private final FiscalYearService fiscalYearService;
+  private final FundService fundService;
+  private final LedgerService ledgerService;
+  private final BaseTransactionService baseTransactionService;
+  private final BudgetService budgetService;
+  private final ExpenseClassRetrieveService expenseClassRetrieveService;
 
-    public InvoiceWorkflowDataHolderBuilder(ExchangeRateProviderResolver exchangeRateProviderResolver,
-                                            FiscalYearService fiscalYearService,
-                                            FundService fundService,
-                                            LedgerService ledgerService,
-                                            BaseTransactionService baseTransactionService,
-                                            BudgetService budgetService,
-                                            ExpenseClassRetrieveService expenseClassRetrieveService) {
-        this.exchangeRateProviderResolver = exchangeRateProviderResolver;
-        this.fiscalYearService = fiscalYearService;
-        this.fundService = fundService;
-        this.ledgerService = ledgerService;
-        this.baseTransactionService = baseTransactionService;
-        this.budgetService = budgetService;
-        this.expenseClassRetrieveService = expenseClassRetrieveService;
-    }
+  public InvoiceWorkflowDataHolderBuilder(ExchangeRateProviderResolver exchangeRateProviderResolver,
+                                          FiscalYearService fiscalYearService,
+                                          FundService fundService,
+                                          LedgerService ledgerService,
+                                          BaseTransactionService baseTransactionService,
+                                          BudgetService budgetService,
+                                          ExpenseClassRetrieveService expenseClassRetrieveService) {
+    this.exchangeRateProviderResolver = exchangeRateProviderResolver;
+    this.fiscalYearService = fiscalYearService;
+    this.fundService = fundService;
+    this.ledgerService = ledgerService;
+    this.baseTransactionService = baseTransactionService;
+    this.budgetService = budgetService;
+    this.expenseClassRetrieveService = expenseClassRetrieveService;
+  }
+
+  public List<InvoiceWorkflowDataHolder> buildHoldersSkeleton(List<InvoiceLine> lines, Invoice invoice) {
+    List<InvoiceWorkflowDataHolder>  holders = lines.stream()
+      .flatMap(invoiceLine -> invoiceLine.getFundDistributions().stream()
+        .map(fundDistribution -> new InvoiceWorkflowDataHolder()
+          .withInvoice(invoice)
+          .withInvoiceLine(invoiceLine)
+          .withFundDistribution(fundDistribution)))
+      .collect(toList());
+
+    List<InvoiceWorkflowDataHolder>  holdersFromAdjustments = invoice.getAdjustments().stream()
+      .flatMap(adjustment -> adjustment.getFundDistributions().stream()
+        .map(fundDistribution -> new InvoiceWorkflowDataHolder()
+          .withInvoice(invoice)
+          .withAdjustment(adjustment)
+          .withFundDistribution(fundDistribution)))
+      .collect(toList());
+
+    holders.addAll(holdersFromAdjustments);
+    return holders;
+  }
 
 
-    public List<InvoiceWorkflowDataHolder> buildHoldersSkeleton(List<InvoiceLine> lines, Invoice invoice) {
-        List<InvoiceWorkflowDataHolder>  holders = lines.stream()
-                .flatMap(invoiceLine -> invoiceLine.getFundDistributions().stream()
-                        .map(fundDistribution -> new InvoiceWorkflowDataHolder()
-                                .withInvoice(invoice)
-                                .withInvoiceLine(invoiceLine)
-                                .withFundDistribution(fundDistribution))).collect(toList());
+  public Future<List<InvoiceWorkflowDataHolder>> withFunds(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
+    List<String> fundIds = holders.stream().map(InvoiceWorkflowDataHolder::getFundId).distinct().collect(toList());
+    return fundService.getFunds(fundIds, requestContext)
+      .map(funds -> funds.stream().collect(toMap(Fund::getId, Function.identity())))
+      .map(idFundMap -> holders.stream()
+        .map(holder -> holder.withFund(idFundMap.get(holder.getFundId())))
+        .collect(toList()));
+  }
 
-        List<InvoiceWorkflowDataHolder>  holdersFromAdjustments = invoice.getAdjustments().stream()
-                .flatMap(adjustment -> adjustment.getFundDistributions().stream()
-                        .map(fundDistribution -> new InvoiceWorkflowDataHolder()
-                                .withInvoice(invoice)
-                                .withAdjustment(adjustment)
-                                .withFundDistribution(fundDistribution))).collect(toList());
+  public Future<List<InvoiceWorkflowDataHolder>> withLedgers(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
+    List<String> ledgerIds = holders.stream().map(InvoiceWorkflowDataHolder::getLedgerId).distinct().collect(toList());
+    return ledgerService.retrieveRestrictedLedgersByIds(ledgerIds, requestContext)
+      .map(ledgers -> ledgers.stream().map(Ledger::getId).collect(toSet()))
+      .map(ids -> holders.stream()
+        .map(holder -> holder.withRestrictExpenditures(ids.contains(holder.getLedgerId())))
+        .collect(toList()));
+  }
 
-        holders.addAll(holdersFromAdjustments);
-        return holders;
-    }
-
-
-    public Future<List<InvoiceWorkflowDataHolder>> withFunds(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
-        List<String> fundIds = holders.stream().map(InvoiceWorkflowDataHolder::getFundId).distinct().collect(toList());
-        return fundService.getFunds(fundIds, requestContext)
-                .map(funds -> funds.stream().collect(toMap(Fund::getId, Function.identity())))
-                .map(idFundMap -> holders.stream()
-                        .map(holder -> holder.withFund(idFundMap.get(holder.getFundId())))
-                        .collect(toList()));
-    }
-
-    public Future<List<InvoiceWorkflowDataHolder>> withLedgers(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
-        List<String> ledgerIds = holders.stream().map(InvoiceWorkflowDataHolder::getLedgerId).distinct().collect(toList());
-        return ledgerService.retrieveRestrictedLedgersByIds(ledgerIds, requestContext)
-                .map(ledgers -> ledgers.stream().map(Ledger::getId).collect(toSet()))
-                .map(ids -> holders.stream()
-                        .map(holder -> holder.withRestrictExpenditures(ids.contains(holder.getLedgerId())))
-                        .collect(toList()));
-    }
-
-    public Future<List<InvoiceWorkflowDataHolder>> withBudgets(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
-        List<String> fundIds = holders.stream().map(InvoiceWorkflowDataHolder::getFundId).distinct().collect(toList());
-        return budgetService.getActiveBudgetsByFundIds(fundIds, requestContext)
-                .map(budgets -> budgets.stream().collect(toMap(Budget::getFundId, Function.identity())))
-                .map(fundIdBudgetMap -> holders.stream()
-                        .map(holder -> holder.withBudget(fundIdBudgetMap.get(holder.getFundId())))
-                        .collect(toList()));
-    }
+  public Future<List<InvoiceWorkflowDataHolder>> withBudgets(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
+    if (holders.size() == 0)
+      return succeededFuture(holders);
+    List<String> fundIds = holders.stream().map(InvoiceWorkflowDataHolder::getFundId).distinct().collect(toList());
+    String invoiceFiscalYearId = holders.get(0).getInvoice().getFiscalYearId();
+    return budgetService.getBudgetsByFundIds(fundIds, invoiceFiscalYearId, requestContext)
+      .map(budgets -> budgets.stream().collect(toMap(Budget::getFundId, Function.identity())))
+      .map(fundIdBudgetMap -> holders.stream()
+        .map(holder -> holder.withBudget(fundIdBudgetMap.get(holder.getFundId())))
+        .collect(toList()));
+  }
 
   public List<InvoiceWorkflowDataHolder> checkMultipleFiscalYears(List<InvoiceWorkflowDataHolder> holders) {
     Map<String, List<InvoiceWorkflowDataHolder>> fiscalYearToHolders = holders.stream()
@@ -138,83 +142,82 @@ public class InvoiceWorkflowDataHolderBuilder {
   }
 
   public Future<List<InvoiceWorkflowDataHolder>> withFiscalYear(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
-        return holders.stream().map(InvoiceWorkflowDataHolder::getBudget).map(Budget::getFiscalYearId).findFirst()
-                .map(s -> fiscalYearService.getFiscalYear(s, requestContext)
-                        .map(fiscalYear -> holders.stream().map(holder -> holder.withFiscalYear(fiscalYear)).collect(toList())))
-                .orElseGet(() -> succeededFuture(holders));
+    if (holders.size() == 0)
+      return succeededFuture(holders);
+    String fiscalYearId = holders.get(0).getBudget().getFiscalYearId();
+    return fiscalYearService.getFiscalYear(fiscalYearId, requestContext)
+      .map(fiscalYear -> holders.stream().map(holder -> holder.withFiscalYear(fiscalYear)).collect(toList()));
+  }
 
-    }
+  public Future<List<InvoiceWorkflowDataHolder>> withEncumbrances(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
+    List<String> trIds = holders.stream().map(InvoiceWorkflowDataHolder::getFundDistribution).map(FundDistribution::getEncumbrance).distinct().filter(Objects::nonNull).collect(toList());
+    return baseTransactionService.getTransactions(trIds, requestContext)
+      .map(transactions -> transactions.stream().collect(toMap(Transaction::getId, Function.identity())))
+      .map(idTransactionMap -> holders.stream()
+        .map(holder -> holder.withEncumbrance(idTransactionMap.get(holder.getFundDistribution().getEncumbrance())))
+        .collect(toList()));
+  }
 
-    public Future<List<InvoiceWorkflowDataHolder>> withEncumbrances(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
-        List<String> trIds = holders.stream().map(InvoiceWorkflowDataHolder::getFundDistribution).map(FundDistribution::getEncumbrance).distinct().filter(Objects::nonNull).collect(toList());
-        return baseTransactionService.getTransactions(trIds, requestContext)
-                .map(transactions -> transactions.stream().collect(toMap(Transaction::getId, Function.identity())))
-                .map(idTransactionMap -> holders.stream()
-                        .map(holder -> holder.withEncumbrance(idTransactionMap.get(holder.getFundDistribution().getEncumbrance())))
-                        .collect(toList()));
-    }
+  public Future<List<InvoiceWorkflowDataHolder>> withExpenseClasses(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
+    List<String> expenseClassIds = holders.stream()
+      .map(InvoiceWorkflowDataHolder::getExpenseClassId)
+      .filter(Objects::nonNull)
+      .distinct()
+      .collect(toList());
+    return expenseClassRetrieveService.getExpenseClasses(expenseClassIds, requestContext)
+      .map(expenseClasses -> expenseClasses.stream().collect(toMap(ExpenseClass::getId, Function.identity())))
+      .map(idExpenseClassMap -> holders.stream()
+        .map(holder -> holder.withExpenseClass(idExpenseClassMap.get(holder.getExpenseClassId())))
+        .collect(toList()));
+  }
 
-    public Future<List<InvoiceWorkflowDataHolder>> withExpenseClasses(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
-        List<String> expenseClassIds = holders.stream()
-                .map(InvoiceWorkflowDataHolder::getExpenseClassId)
-                .filter(Objects::nonNull)
-                .distinct()
-                .collect(toList());
-        return expenseClassRetrieveService.getExpenseClasses(expenseClassIds, requestContext)
-                .map(expenseClasses -> expenseClasses.stream().collect(toMap(ExpenseClass::getId, Function.identity())))
-                .map(idExpenseClassMap -> holders.stream()
-                        .map(holder -> holder.withExpenseClass(idExpenseClassMap.get(holder.getExpenseClassId())))
-                        .collect(toList()));
-    }
+  public Future<List<InvoiceWorkflowDataHolder>> withExchangeRate(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
+    return holders.stream()
+      .findFirst()
+      .map(holder -> requestContext.getContext().<CurrencyConversion>executeBlocking(event -> {
+        Invoice invoice = holder.getInvoice();
+        FiscalYear fiscalYear = holder.getFiscalYear();
+        ConversionQuery conversionQuery = HelperUtils.buildConversionQuery(invoice, fiscalYear.getCurrency());
+        ExchangeRateProvider exchangeRateProvider = exchangeRateProviderResolver.resolve(conversionQuery, requestContext);
+        invoice.setExchangeRate(exchangeRateProvider.getExchangeRate(conversionQuery).getFactor().doubleValue());
+        event.complete(exchangeRateProvider.getCurrencyConversion(conversionQuery));
+      })
+        .map(conversion -> holders.stream()
+          .map(h -> h.withConversion(conversion))
+          .collect(toList())))
+      .orElseGet(() -> succeededFuture(holders));
 
-    public Future<List<InvoiceWorkflowDataHolder>> withExchangeRate(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
-      return holders.stream()
-        .findFirst()
-        .map(holder -> requestContext.getContext().<CurrencyConversion>executeBlocking(event -> {
-          Invoice invoice = holder.getInvoice();
-          FiscalYear fiscalYear = holder.getFiscalYear();
-          ConversionQuery conversionQuery = HelperUtils.buildConversionQuery(invoice, fiscalYear.getCurrency());
-          ExchangeRateProvider exchangeRateProvider = exchangeRateProviderResolver.resolve(conversionQuery, requestContext);
-          invoice.setExchangeRate(exchangeRateProvider.getExchangeRate(conversionQuery).getFactor().doubleValue());
-          event.complete(exchangeRateProvider.getCurrencyConversion(conversionQuery));
-        })
-          .map(conversion -> holders.stream()
-            .map(h -> h.withConversion(conversion))
-            .collect(toList())))
-        .orElseGet(() -> succeededFuture(holders));
+  }
 
-    }
+  public Future<List<InvoiceWorkflowDataHolder>> withExistingTransactions(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
+    return holders.stream().findFirst().map(holder -> {
+      String query = String.format("sourceInvoiceId==%s AND transactionType==Pending payment", holder.getInvoice().getId());
+      return baseTransactionService.getTransactions(query, 0, holders.size(), requestContext)
+        .map(TransactionCollection::getTransactions)
+        .map(transactions -> mapTransactionsToHolders(transactions, holders));
+      }).orElseGet(() -> succeededFuture(holders));
+  }
 
-    public Future<List<InvoiceWorkflowDataHolder>> withExistingTransactions(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
-      return holders.stream().findFirst().map(holder -> {
-        String query = String.format("sourceInvoiceId==%s AND transactionType==Pending payment", holder.getInvoice().getId());
-        return baseTransactionService.getTransactions(query, 0, holders.size(), requestContext)
-            .map(TransactionCollection::getTransactions)
-            .map(transactions -> mapTransactionsToHolders(transactions, holders));
-        }).orElseGet(() -> succeededFuture(holders));
-    }
+  private List<InvoiceWorkflowDataHolder> mapTransactionsToHolders(List<Transaction> transactions, List<InvoiceWorkflowDataHolder> holders) {
+    return holders.stream().map(holder -> holder.withExistingTransaction(mapTransactionToHolder(holder, transactions))).collect(toList());
+  }
 
-    private List<InvoiceWorkflowDataHolder> mapTransactionsToHolders(List<Transaction> transactions, List<InvoiceWorkflowDataHolder> holders) {
-      return holders.stream().map(holder -> holder.withExistingTransaction(mapTransactionToHolder(holder, transactions))).collect(toList());
-    }
+  private Transaction mapTransactionToHolder(InvoiceWorkflowDataHolder holder, List<Transaction> transactions) {
+    Transaction transaction = transactions.stream()
+      .filter(tr -> isTransactionRefersToHolder(tr, holder))
+      .findFirst()
+      .orElseGet(() -> new Transaction().withAmount(0d).withCurrency(holder.getFyCurrency()));
+    //Added remove so that in case of multiple transaction update our holder won't hold the same transaction because of findFirst().
+    //And in this case we can avoid "Primary Key Violation" when working with invoice summaries.
+    transactions.remove(transaction);
+    return transaction;
+  }
 
-    private Transaction mapTransactionToHolder(InvoiceWorkflowDataHolder holder, List<Transaction> transactions) {
-      Transaction transaction = transactions.stream()
-        .filter(tr -> isTransactionRefersToHolder(tr, holder))
-        .findFirst()
-        .orElseGet(() -> new Transaction().withAmount(0d).withCurrency(holder.getFyCurrency()));
-      //Added remove so that in case of multiple transaction update our holder wont hold the same transaction because of findFirst().
-      //And in this case we can avoid "Primary Key Violation" when working with invoice summaries.
-      transactions.remove(transaction);
-      return transaction;
-    }
-
-    private boolean isTransactionRefersToHolder(Transaction transaction, InvoiceWorkflowDataHolder holder) {
-      return !transaction.getFromFundId()
-              .equals(holder.getFundId())
-              || !Objects.equals(transaction.getSourceInvoiceLineId(), holder.getInvoiceLineId())
-              || !Objects.equals(transaction.getExpenseClassId(), holder.getFundDistribution().getEncumbrance())
-              || !Objects.nonNull(transaction.getAwaitingPayment())
-              || Objects.equals(transaction.getAwaitingPayment().getEncumbranceId(),holder.getFundDistribution().getEncumbrance());
-    }
+  private boolean isTransactionRefersToHolder(Transaction transaction, InvoiceWorkflowDataHolder holder) {
+    return !transaction.getFromFundId().equals(holder.getFundId())
+      || !Objects.equals(transaction.getSourceInvoiceLineId(), holder.getInvoiceLineId())
+      || !Objects.equals(transaction.getExpenseClassId(), holder.getFundDistribution().getEncumbrance())
+      || !Objects.nonNull(transaction.getAwaitingPayment())
+      || Objects.equals(transaction.getAwaitingPayment().getEncumbranceId(),holder.getFundDistribution().getEncumbrance());
+  }
 }

--- a/src/main/java/org/folio/invoices/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/invoices/utils/ErrorCodes.java
@@ -41,6 +41,7 @@ public enum ErrorCodes {
   CANNOT_ADD_ADJUSTMENTS("cannotAddAdjustment", "Prorated adjustment cannot be adde because it is not present on invoice level"),
   APPROVED_OR_PAID_INVOICE_DELETE_FORBIDDEN("approvedOrPaidInvoiceDeleteForbiddenError", "Approved or paid invoice can not be deleted"),
   BUDGET_NOT_FOUND("budgetNotFoundByFundId", "Budget not found by fundId"),
+  BUDGET_NOT_FOUND_USING_FISCAL_YEAR_ID("budgetNotFoundByFundIdAndFiscalYearId", "Budget not found by fund id and fiscal year id"),
   LEDGER_NOT_FOUND("ledgerNotFound", "Ledger not found"),
   FUND_CANNOT_BE_PAID("fundCannotBePaid", "Fund cannot be paid due to restrictions"),
   INACTIVE_EXPENSE_CLASS("inactiveExpenseClass", "Expense class is Inactive"),

--- a/src/main/java/org/folio/services/finance/budget/BudgetService.java
+++ b/src/main/java/org/folio/services/finance/budget/BudgetService.java
@@ -61,7 +61,7 @@ public class BudgetService {
       .withQuery(String.format(QUERY_BY_FUND_ID_AND_FISCAL_YEAR_ID, fundId, fiscalYearId));
     return restClient.get(requestEntry, BudgetCollection.class, requestContext)
       .map(budgetCollection -> {
-        if (budgetCollection.getBudgets().size() < 1) {
+        if (budgetCollection.getBudgets().isEmpty()) {
           List<Parameter> parameters = List.of(
             new Parameter().withKey("fundId").withValue(fundId),
             new Parameter().withKey("fiscalYearId").withValue(fiscalYearId)

--- a/src/main/java/org/folio/services/finance/budget/BudgetService.java
+++ b/src/main/java/org/folio/services/finance/budget/BudgetService.java
@@ -2,6 +2,7 @@ package org.folio.services.finance.budget;
 
 import static java.util.stream.Collectors.toList;
 import static org.folio.invoices.utils.ErrorCodes.BUDGET_NOT_FOUND;
+import static org.folio.invoices.utils.ErrorCodes.BUDGET_NOT_FOUND_USING_FISCAL_YEAR_ID;
 import static org.folio.invoices.utils.HelperUtils.collectResultsOnSuccess;
 import static org.folio.invoices.utils.HelperUtils.convertIdsToCqlQuery;
 import static org.folio.invoices.utils.ResourcePathResolver.BUDGETS;
@@ -30,6 +31,7 @@ public class BudgetService {
 
   private static final String BUDGETS_ENDPOINT = resourcesPath(BUDGETS);
   private static final String ACTIVE_BUDGET_ENDPOINT = "/finance/funds/{id}/budget";
+  private static final String QUERY_BY_FUND_ID_AND_FISCAL_YEAR_ID = "fundId==%s and fiscalYearId==%s";
 
   private final RestClient restClient;
 
@@ -37,27 +39,53 @@ public class BudgetService {
       this.restClient = restClient;
   }
 
-  public Future<List<Budget>> getActiveBudgetsByFundIds(Collection<String> fundIds, RequestContext requestContext) {
+  public Future<List<Budget>> getBudgetsByFundIds(Collection<String> fundIds, String invoiceFiscalYearId,
+      RequestContext requestContext) {
     List<Future<Budget>> futures = fundIds.stream()
-            .distinct()
-            .map(fundId -> getActiveBudgetByFundId(fundId, requestContext))
-            .collect(toList());
+      .distinct()
+      .map(fundId -> getBudgetByFundId(fundId, invoiceFiscalYearId, requestContext))
+      .collect(toList());
 
     return collectResultsOnSuccess(futures);
   }
 
+  private Future<Budget> getBudgetByFundId(String fundId, String invoiceFiscalYearId, RequestContext requestContext) {
+    if (invoiceFiscalYearId == null)
+      return getActiveBudgetByFundId(fundId, requestContext);
+    return getBudgetByFundIdAndFiscalYearId(fundId, invoiceFiscalYearId, requestContext);
+  }
+
+  private Future<Budget> getBudgetByFundIdAndFiscalYearId(String fundId, String fiscalYearId,
+      RequestContext requestContext) {
+    RequestEntry requestEntry = new RequestEntry(BUDGETS_ENDPOINT)
+      .withQuery(String.format(QUERY_BY_FUND_ID_AND_FISCAL_YEAR_ID, fundId, fiscalYearId));
+    return restClient.get(requestEntry, BudgetCollection.class, requestContext)
+      .map(budgetCollection -> {
+        if (budgetCollection.getBudgets().size() < 1) {
+          List<Parameter> parameters = List.of(
+            new Parameter().withKey("fundId").withValue(fundId),
+            new Parameter().withKey("fiscalYearId").withValue(fiscalYearId)
+          );
+          throw new HttpException(404, BUDGET_NOT_FOUND_USING_FISCAL_YEAR_ID.toError().withParameters(parameters));
+        }
+        return budgetCollection.getBudgets().get(0);
+      })
+      .onFailure(t -> log.error("Error getting budget by fundId and fiscalYearId, fundId={}, fiscalYearId={}",
+        fundId, fiscalYearId, t));
+  }
+
   private Future<Budget> getActiveBudgetByFundId(String fundId, RequestContext requestContext) {
     RequestEntry requestEntry = new RequestEntry(ACTIVE_BUDGET_ENDPOINT)
-        .withId(fundId);
+      .withId(fundId);
     return restClient.get(requestEntry, Budget.class, requestContext)
-            .recover(t -> {
-                Throwable cause = Objects.isNull(t.getCause()) ? t : t.getCause();
-                if (cause instanceof HttpException) {
-                    throw new HttpException(404, BUDGET_NOT_FOUND
-                            .toError().withParameters(Collections.singletonList(new Parameter().withKey("fund").withValue(fundId))));
-                }
-                throw new CompletionException(t.getCause());
-            });
+      .recover(t -> {
+        Throwable cause = Objects.isNull(t.getCause()) ? t : t.getCause();
+        if (cause instanceof HttpException) {
+          throw new HttpException(404, BUDGET_NOT_FOUND
+            .toError().withParameters(Collections.singletonList(new Parameter().withKey("fund").withValue(fundId))));
+        }
+        throw new CompletionException(t.getCause());
+      });
   }
 
   public Future<List<Budget>> getActiveBudgetListByFundIds(List<String> fundIds, RequestContext requestContext) {

--- a/src/test/java/org/folio/ApiTestSuite.java
+++ b/src/test/java/org/folio/ApiTestSuite.java
@@ -37,10 +37,11 @@ import org.folio.schemas.xsd.BatchVoucherSchemaXSDTest;
 import org.folio.services.InvoiceLinesRetrieveServiceTest;
 import org.folio.services.InvoiceRetrieveServiceTest;
 import org.folio.services.VoucherLineServiceTest;
-import org.folio.services.finance.BudgetExpenseClassTest;
+import org.folio.services.finance.budget.BudgetExpenseClassTest;
 import org.folio.services.finance.CurrentFiscalYearServiceTest;
 import org.folio.services.finance.ManualCurrencyConversionTest;
 import org.folio.services.finance.ManualExchangeRateProviderTest;
+import org.folio.services.finance.budget.BudgetServiceTest;
 import org.folio.services.finance.expense.ExpenseClassRetrieveServiceTest;
 import org.folio.services.finance.transaction.BaseTransactionServiceTest;
 import org.folio.services.finance.transaction.PendingPaymentWorkflowServiceTest;
@@ -279,6 +280,10 @@ public class ApiTestSuite {
 
   @Nested
   class BudgetExpenseClassTestNested extends BudgetExpenseClassTest {
+  }
+
+  @Nested
+  class BudgetServiceTestNested extends BudgetServiceTest {
   }
 
   @Nested

--- a/src/test/java/org/folio/services/finance/budget/BudgetExpenseClassTest.java
+++ b/src/test/java/org/folio/services/finance/budget/BudgetExpenseClassTest.java
@@ -1,4 +1,4 @@
-package org.folio.services.finance;
+package org.folio.services.finance.budget;
 
 import static io.vertx.core.Future.succeededFuture;
 import static org.folio.invoices.utils.ErrorCodes.BUDGET_EXPENSE_CLASS_NOT_FOUND;

--- a/src/test/java/org/folio/services/finance/budget/BudgetServiceTest.java
+++ b/src/test/java/org/folio/services/finance/budget/BudgetServiceTest.java
@@ -1,0 +1,141 @@
+package org.folio.services.finance.budget;
+
+import io.vertx.core.Future;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.folio.invoices.rest.exceptions.HttpException;
+import org.folio.rest.acq.model.finance.Budget;
+import org.folio.rest.acq.model.finance.BudgetCollection;
+import org.folio.rest.core.RestClient;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.core.models.RequestEntry;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.folio.invoices.utils.ErrorCodes.BUDGET_NOT_FOUND_USING_FISCAL_YEAR_ID;
+import static org.folio.invoices.utils.HelperUtils.encodeQuery;
+import static org.folio.invoices.utils.ResourcePathResolver.BUDGETS;
+import static org.folio.invoices.utils.ResourcePathResolver.resourcesPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+public class BudgetServiceTest {
+  AutoCloseable closeable;
+
+  @InjectMocks
+  private BudgetService budgetService;
+
+  @Mock
+  private RestClient restClient;
+
+  @Mock
+  private RequestContext requestContext;
+
+  @BeforeEach
+  public void initMocks() {
+    closeable = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  void resetMocks() throws Exception {
+    closeable.close();
+  }
+
+  @Test
+  void shouldThrowErrorWhenBudgetIsNotFoundUsingFiscalYearId(VertxTestContext vertxTestContext) {
+    String fundId = UUID.randomUUID().toString();
+    List<String> fundIds = List.of(fundId);
+    String invoiceFiscalYearId = UUID.randomUUID().toString();
+    BudgetCollection budgetCollection = new BudgetCollection()
+      .withBudgets(List.of())
+      .withTotalRecords(0);
+    when(restClient.get(any(RequestEntry.class), any(), any()))
+      .thenReturn(Future.succeededFuture(budgetCollection));
+
+    Future<List<Budget>> f = budgetService.getBudgetsByFundIds(fundIds, invoiceFiscalYearId, requestContext);
+
+    vertxTestContext.assertFailure(f)
+      .onComplete(result -> {
+        assertThat(result.cause(), instanceOf(HttpException.class));
+        HttpException exception = (HttpException) result.cause();
+        assertEquals(404, exception.getCode());
+        Errors errors = exception.getErrors();
+        Error error = errors.getErrors().get(0);
+        assertEquals(BUDGET_NOT_FOUND_USING_FISCAL_YEAR_ID.getCode(), error.getCode());
+        vertxTestContext.completeNow();
+      });
+  }
+
+  @Test
+  void shouldReturnBudgetsWhenGettingBudgetsUsingFiscalYearId(VertxTestContext vertxTestContext) {
+    String fundId = UUID.randomUUID().toString();
+    List<String> fundIds = List.of(fundId);
+    String invoiceFiscalYearId = UUID.randomUUID().toString();
+    Budget budget = new Budget()
+      .withId(UUID.randomUUID().toString());
+    BudgetCollection budgetCollection = new BudgetCollection()
+      .withBudgets(List.of(budget))
+      .withTotalRecords(1);
+    String query = String.format("fundId==%s and fiscalYearId==%s", fundId, invoiceFiscalYearId);
+    ArgumentCaptor<RequestEntry> requestEntryCaptor = ArgumentCaptor.forClass(RequestEntry.class);
+    when(restClient.get(requestEntryCaptor.capture(), any(), any()))
+      .thenReturn(Future.succeededFuture(budgetCollection));
+
+    Future<List<Budget>> f = budgetService.getBudgetsByFundIds(fundIds, invoiceFiscalYearId, requestContext);
+
+    vertxTestContext.assertComplete(f)
+      .onComplete(result -> {
+        verify(restClient, times(1)).get(any(RequestEntry.class), any(), any());
+        List<RequestEntry> requestEntries = requestEntryCaptor.getAllValues();
+        assertEquals(requestEntries.get(0).getBaseEndpoint(), resourcesPath(BUDGETS));
+        assertEquals(requestEntries.get(0).getQueryParams().get("query"), encodeQuery(query));
+        List<Budget> budgets = result.result();
+        assertEquals(1, budgets.size());
+        assertEquals(budget.getId(), budgets.get(0).getId());
+        vertxTestContext.completeNow();
+      });
+  }
+
+  @Test
+  void shouldReturnActiveBudgetsWhenGettingBudgetsWithoutUsingFiscalYearId(VertxTestContext vertxTestContext) {
+    String fundId = UUID.randomUUID().toString();
+    List<String> fundIds = List.of(fundId);
+    Budget budget = new Budget()
+      .withId(UUID.randomUUID().toString());
+    ArgumentCaptor<RequestEntry> requestEntryCaptor = ArgumentCaptor.forClass(RequestEntry.class);
+    when(restClient.get(requestEntryCaptor.capture(), any(), any()))
+      .thenReturn(Future.succeededFuture(budget));
+
+    Future<List<Budget>> f = budgetService.getBudgetsByFundIds(fundIds, null, requestContext);
+
+    vertxTestContext.assertComplete(f)
+      .onComplete(result -> {
+        verify(restClient, times(1)).get(any(RequestEntry.class), any(), any());
+        List<RequestEntry> requestEntries = requestEntryCaptor.getAllValues();
+        assertEquals(requestEntries.get(0).getBaseEndpoint(), "/finance/funds/{id}/budget");
+        assertEquals(requestEntries.get(0).getPathParams().get("id"), fundId);
+        List<Budget> budgets = result.result();
+        assertEquals(1, budgets.size());
+        assertEquals(budget.getId(), budgets.get(0).getId());
+        vertxTestContext.completeNow();
+      });
+  }
+
+}


### PR DESCRIPTION
## Purpose
[MODINVOICE-463](https://issues.folio.org/browse/MODINVOICE-463) - Provide fiscalYear field for pending payments, payments and credits

## Approach
- When defined, use the invoice fiscal year id to retrieve the budgets for processing approve&pay. The budgets' fiscal year is already used to create transactions.
- Updated unit tests
- Fixed indents

See [related integration test](https://github.com/folio-org/folio-integration-tests/pull/928).

#### TODOS and Open Questions
Right now the fiscal year must be given in the invoice before creating the lines, otherwise there could be an error if a current budget is missing for a fund that has a budget in the past fiscal year we want to use. There are similar issues with expense classes. We will have to either change the checks, or provide the invoice fiscal year earlier in the process.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate action.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code are 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
