### PR TITLE
[MODINVOICE-474] Update encumbrance links with fiscal year

### DIFF
--- a/src/main/java/org/folio/invoices/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/invoices/utils/ErrorCodes.java
@@ -60,7 +60,8 @@ public enum ErrorCodes {
   ERROR_UNRELEASING_ENCUMBRANCES("errorUnreleasingEncumbrances", "Error unreleasing encumbrances after cancelling the invoice"),
   MULTIPLE_FISCAL_YEARS("multipleFiscalYears", "Multiple fiscal years are used with the funds %s and %s."),
   COULD_NOT_FIND_VALID_FISCAL_YEAR("couldNotFindValidFiscalYear", "Could not find any valid fiscal year with a budget for all funds in the invoice"),
-  MORE_THAN_ONE_FISCAL_YEAR_SERIES("moreThanOneFiscalYearSeries", "Fund distributions cannot reference more than one fiscal year series. Please edit fund distributions so they all come from the same fiscal year series.");
+  MORE_THAN_ONE_FISCAL_YEAR_SERIES("moreThanOneFiscalYearSeries", "Fund distributions cannot reference more than one fiscal year series. Please edit fund distributions so they all come from the same fiscal year series."),
+  CANNOT_RESET_INVOICE_FISCAL_YEAR("cannotResetInvoiceFiscalYear", "Invoice fiscal year cannot be set to null if it was previously defined");
 
   private final String code;
   private final String description;

--- a/src/main/java/org/folio/services/finance/transaction/EncumbranceService.java
+++ b/src/main/java/org/folio/services/finance/transaction/EncumbranceService.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.models.InvoiceWorkflowDataHolder;

--- a/src/main/java/org/folio/services/finance/transaction/EncumbranceService.java
+++ b/src/main/java/org/folio/services/finance/transaction/EncumbranceService.java
@@ -1,14 +1,21 @@
 package org.folio.services.finance.transaction;
 
+import static io.vertx.core.Future.succeededFuture;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static org.folio.invoices.utils.HelperUtils.collectResultsOnSuccess;
 import static org.folio.invoices.utils.HelperUtils.convertIdsToCqlQuery;
 import static org.folio.rest.RestConstants.MAX_IDS_FOR_GET_RQ;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.models.InvoiceWorkflowDataHolder;
 import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.acq.model.finance.OrderTransactionSummary;
 import org.folio.rest.acq.model.finance.Transaction;
@@ -17,8 +24,12 @@ import org.folio.rest.core.models.RequestContext;
 
 import io.vertx.core.Future;
 import one.util.streamex.StreamEx;
+import org.folio.rest.jaxrs.model.FundDistribution;
+import org.folio.rest.jaxrs.model.Invoice;
+import org.folio.rest.jaxrs.model.InvoiceLine;
 
 public class EncumbranceService {
+  private static final Logger log = LogManager.getLogger();
 
   private final BaseTransactionService baseTransactionService;
   private final OrderTransactionSummaryService orderTransactionSummaryService;
@@ -29,17 +40,20 @@ public class EncumbranceService {
     this.orderTransactionSummaryService = orderTransactionSummaryService;
   }
 
-  public Future<List<Transaction>> getEncumbrancesByPoLineIds(List<String> poLineIds, RequestContext requestContext) {
-    List<Future<TransactionCollection>> expenseClassesFutureList = StreamEx
+  public Future<List<Transaction>> getEncumbrancesByPoLineIds(List<String> poLineIds, String fiscalYearId,
+      RequestContext requestContext) {
+    List<Future<TransactionCollection>> transactionsFutureList = StreamEx
       .ofSubLists(poLineIds, MAX_IDS_FOR_GET_RQ)
-      .map(this::buildEncumbranceChunckQueryByPoLineIds)
+      .map(lineIds -> buildEncumbranceChunckQueryByPoLineIds(lineIds, fiscalYearId))
       .map(query -> baseTransactionService.getTransactions(query, 0, Integer.MAX_VALUE, requestContext))
       .collect(toList());
 
-    return collectResultsOnSuccess(expenseClassesFutureList)
-      .map(expenseClassCollections ->
-        expenseClassCollections.stream().flatMap(col -> col.getTransactions().stream()).collect(toList())
-      );
+    return collectResultsOnSuccess(transactionsFutureList)
+      .map(transactionCollections ->
+        transactionCollections.stream().flatMap(col -> col.getTransactions().stream()).collect(toList())
+      )
+      .onFailure(t -> log.error(String.format("Error getting encumbrances by po line ids, poLineIds=%s, fiscalYearId=%s",
+        poLineIds, fiscalYearId), t));
   }
 
   public Future<Void> unreleaseEncumbrances(List<Transaction> transactions, RequestContext requestContext) {
@@ -51,9 +65,11 @@ public class EncumbranceService {
     return GenericCompositeFuture.join(futures).mapEmpty();
   }
 
-  private String buildEncumbranceChunckQueryByPoLineIds(List<String> poLineIds) {
-    return "transactionType==Encumbrance and " +
-      convertIdsToCqlQuery(poLineIds, "encumbrance.sourcePoLineId", true);
+  private String buildEncumbranceChunckQueryByPoLineIds(List<String> poLineIds, String fiscalYearId) {
+    String transactionTypeFilter = "transactionType==Encumbrance";
+    String fiscalYearFilter = fiscalYearId == null ? "" : String.format(" AND fiscalYearId==%s", fiscalYearId);
+    String idFilter = " AND " + convertIdsToCqlQuery(poLineIds, "encumbrance.sourcePoLineId", true);
+    return String.format("%s%s%s", transactionTypeFilter, fiscalYearFilter, idFilter);
   }
 
   private Future<Void> unreleaseEncumbrancesByOrderId(String orderId, List<Transaction> transactions,
@@ -67,6 +83,77 @@ public class EncumbranceService {
     return new OrderTransactionSummary()
       .withId(orderId)
       .withNumTransactions(transactions.size());
+  }
+
+  public Future<List<InvoiceWorkflowDataHolder>> updateEncumbranceLinksForFiscalYear(Invoice invoice,
+      List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
+    // this method is used when an invoice line is created, with the related holders
+    if (invoice.getFiscalYearId() == null) {
+      return succeededFuture(holders);
+    }
+    boolean updateNeeded = holders.stream()
+      .map(InvoiceWorkflowDataHolder::getEncumbrance)
+      .filter(Objects::nonNull)
+      .anyMatch(encumbrance -> !invoice.getFiscalYearId().equals(encumbrance.getFiscalYearId()));
+    if (!updateNeeded) {
+      return succeededFuture(holders);
+    }
+    return updateInvoiceLinesEncumbranceLinks(holders, invoice.getFiscalYearId(), requestContext)
+      .map(linesToUpdate -> holders);
+  }
+
+  public Future<List<InvoiceLine>> updateInvoiceLinesEncumbranceLinks(List<InvoiceWorkflowDataHolder> holders,
+      String fiscalYearId, RequestContext requestContext) {
+    List<InvoiceWorkflowDataHolder> relevantHolders = holders.stream()
+      .filter(holder -> holder.getInvoiceLine() != null && holder.getInvoiceLine().getPoLineId() != null)
+      .collect(toList());
+    if (relevantHolders.isEmpty()) {
+      return succeededFuture(List.of());
+    }
+    List<String> poLineIds = getPoLineIds(relevantHolders);
+    return getEncumbrancesByPoLineIds(poLineIds, fiscalYearId, requestContext)
+      .map(encumbrances -> encumbrances.stream()
+        .collect(groupingBy(encumbr -> Pair.of(encumbr.getEncumbrance().getSourcePoLineId(), encumbr.getFromFundId()))))
+      .map(poLineIdAndFundIdToEncumbrances -> updateFundDistributionsWithEncumbrances(relevantHolders,
+        poLineIdAndFundIdToEncumbrances))
+      .onFailure(t -> log.error(String.format("Error updating invoice lines encumbrance links, invoiceId=%s, fiscalYearId=%s",
+        relevantHolders.get(0).getInvoice().getId(), fiscalYearId), t));
+  }
+
+  private List<String> getPoLineIds(List<InvoiceWorkflowDataHolder> holders) {
+    return holders.stream()
+      .map(holder -> holder.getInvoiceLine().getPoLineId())
+      .distinct()
+      .collect(toList());
+  }
+
+  private List<InvoiceLine> updateFundDistributionsWithEncumbrances(List<InvoiceWorkflowDataHolder> holders,
+      Map<Pair<String, String>, List<Transaction>> poLineIdAndFundIdToEncumbrances) {
+    List<InvoiceLine> linesToUpdate = new ArrayList<>();
+    for (InvoiceWorkflowDataHolder holder : holders) {
+      Pair<String, String> poLineIdAndFundId = Pair.of(holder.getInvoiceLine().getPoLineId(), holder.getFundId());
+      List<Transaction> encumbrances = poLineIdAndFundIdToEncumbrances.get(poLineIdAndFundId);
+      FundDistribution fundDistribution = holder.getFundDistribution();
+      if (encumbrances == null || encumbrances.isEmpty()) {
+        if (fundDistribution.getEncumbrance() != null) {
+          fundDistribution.withEncumbrance(null);
+          holder.withEncumbrance(null);
+          if (!linesToUpdate.contains(holder.getInvoiceLine())) {
+            linesToUpdate.add(holder.getInvoiceLine());
+          }
+        }
+      } else {
+        Transaction encumbrance = encumbrances.get(0);
+        if (!encumbrance.getId().equals(fundDistribution.getEncumbrance())) {
+          fundDistribution.withEncumbrance(encumbrance.getId());
+          holder.withEncumbrance(encumbrance);
+          if (!linesToUpdate.contains(holder.getInvoiceLine())) {
+            linesToUpdate.add(holder.getInvoiceLine());
+          }
+        }
+      }
+    }
+    return linesToUpdate;
   }
 
 }

--- a/src/test/java/org/folio/ApiTestSuite.java
+++ b/src/test/java/org/folio/ApiTestSuite.java
@@ -44,6 +44,7 @@ import org.folio.services.finance.ManualExchangeRateProviderTest;
 import org.folio.services.finance.budget.BudgetServiceTest;
 import org.folio.services.finance.expense.ExpenseClassRetrieveServiceTest;
 import org.folio.services.finance.transaction.BaseTransactionServiceTest;
+import org.folio.services.finance.transaction.EncumbranceServiceTest;
 import org.folio.services.finance.transaction.PendingPaymentWorkflowServiceTest;
 import org.folio.services.ftp.FTPVertxCommandLoggerTest;
 import org.folio.services.ftp.FtpUploadServiceTest;
@@ -252,6 +253,10 @@ public class ApiTestSuite {
 
   @Nested
   class BaseTransactionServiceTestNested extends BaseTransactionServiceTest {
+  }
+
+  @Nested
+  class EncumbranceServiceTestNested extends EncumbranceServiceTest {
   }
 
   @Nested

--- a/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
@@ -135,6 +135,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.invoices.utils.InvoiceProtectedFields;
 import org.folio.rest.acq.model.finance.Budget;
 import org.folio.rest.acq.model.finance.Budget.BudgetStatus;
+import org.folio.rest.acq.model.finance.Encumbrance;
 import org.folio.rest.acq.model.finance.Fund;
 import org.folio.rest.acq.model.finance.FundCollection;
 import org.folio.rest.acq.model.finance.InvoiceTransactionSummary;
@@ -214,6 +215,8 @@ public class InvoicesApiTest extends ApiTestBase {
   private static final String STATUS = "status";
   private static final String INVALID_CURRENCY = "ABC";
   public static final String EXISTING_FUND_ID = "1d1574f1-9196-4a57-8d1f-3b2e4309eb81";
+  public static final String EXISTING_FUND_ID_2 = "2d1574f1-919cc4a57-8d1f-3b2e4619eb81";
+  public static final String EXISTING_FUND_ID_3 = "7fbd5d84-62d1-44c6-9c45-6cb173998bbd";
   private static final String FUND_ID_WITH_NOT_ENOUGH_AMOUNT_IN_BUDGET = "2d1574f1-919cc4a57-8d1f-3b2e4619eb81";
   public static final String FUND_ID_WITH_NOT_ACTIVE_BUDGET = "3d1574f1-919cc4a57-8d1f-3b2e4619eb81";
   public static final String EXISTING_LEDGER_ID = "a3ec5552-c4a4-4a15-a57c-0046db536369";
@@ -1708,22 +1711,56 @@ public class InvoicesApiTest extends ApiTestBase {
     invoiceLine.setAdjustmentsTotal(0d);
     invoiceLine.setAdjustments(emptyList());
 
+    Transaction enc1 = new Transaction()
+      .withId(UUID.randomUUID().toString())
+      .withFiscalYearId(FISCAL_YEAR_ID)
+      .withTransactionType(Transaction.TransactionType.ENCUMBRANCE)
+      .withAmount(1.00)
+      .withCurrency("USD")
+      .withFromFundId(EXISTING_FUND_ID)
+      .withToFundId(EXISTING_FUND_ID)
+      .withEncumbrance(new Encumbrance()
+        .withSourcePoLineId("0610be6d-0ddd-494b-b867-19f63d8b5d6d"));
+    addMockEntry(FINANCE_TRANSACTIONS, enc1);
+    Transaction enc2 = new Transaction()
+      .withId(UUID.randomUUID().toString())
+      .withFiscalYearId(FISCAL_YEAR_ID)
+      .withTransactionType(Transaction.TransactionType.ENCUMBRANCE)
+      .withAmount(1.00)
+      .withCurrency("USD")
+      .withFromFundId(EXISTING_FUND_ID_2)
+      .withToFundId(EXISTING_FUND_ID_2)
+      .withEncumbrance(new Encumbrance()
+        .withSourcePoLineId("0610be6d-0ddd-494b-b867-19f63d8b5d6d"));
+    addMockEntry(FINANCE_TRANSACTIONS, enc2);
+    Transaction enc3 = new Transaction()
+      .withId(UUID.randomUUID().toString())
+      .withFiscalYearId(FISCAL_YEAR_ID)
+      .withTransactionType(Transaction.TransactionType.ENCUMBRANCE)
+      .withAmount(1.00)
+      .withCurrency("USD")
+      .withFromFundId(EXISTING_FUND_ID_3)
+      .withToFundId(EXISTING_FUND_ID_3)
+      .withEncumbrance(new Encumbrance()
+        .withSourcePoLineId("0610be6d-0ddd-494b-b867-19f63d8b5d6d"));
+    addMockEntry(FINANCE_TRANSACTIONS, enc3);
+
     invoiceLine.setSubTotal(10d);
     FundDistribution fd1 = new FundDistribution()
       .withDistributionType(FundDistribution.DistributionType.PERCENTAGE)
       .withFundId(EXISTING_FUND_ID)
       .withValue(50d)
-      .withEncumbrance(UUID.randomUUID().toString());
+      .withEncumbrance(enc1.getId());
     FundDistribution fd2 = new FundDistribution()
       .withDistributionType(AMOUNT)
-      .withFundId(EXISTING_FUND_ID)
+      .withFundId(EXISTING_FUND_ID_2)
       .withValue(3d)
-      .withEncumbrance(UUID.randomUUID().toString());
+      .withEncumbrance(enc2.getId());
     FundDistribution fd3 = new FundDistribution()
       .withDistributionType(AMOUNT)
-      .withFundId(EXISTING_FUND_ID)
+      .withFundId(EXISTING_FUND_ID_3)
       .withValue(2d)
-      .withEncumbrance(UUID.randomUUID().toString());
+      .withEncumbrance(enc3.getId());
 
     List<FundDistribution> fundDistributions = Arrays.asList(fd1, fd2, fd3);
     invoiceLine.setFundDistributions(fundDistributions);

--- a/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
@@ -2528,8 +2528,10 @@ public class InvoicesApiTest extends ApiTestBase {
   void testUpdateInvoiceTransitionToPaidWithNullFiscalYearIdTransactionsAlreadyExists() {
     logger.info("=== Test transition invoice to paid with null fiscalYearId - transactions already exist in finance storage ===");
 
-    Invoice reqData = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH).mapTo(Invoice.class).withStatus(Invoice.Status.PAID);
-    reqData.setFiscalYearId(null);
+    JsonObject initialData = getMockAsJson(APPROVED_INVOICE_SAMPLE_PATH);
+    initialData.putNull("fiscalYearId");
+    addMockEntry(INVOICES, initialData);
+    Invoice reqData = initialData.mapTo(Invoice.class).withStatus(Invoice.Status.PAID);
     String id = reqData.getId();
 
     // Prepare existing transaction

--- a/src/test/java/org/folio/services/finance/transaction/EncumbranceServiceTest.java
+++ b/src/test/java/org/folio/services/finance/transaction/EncumbranceServiceTest.java
@@ -1,0 +1,242 @@
+package org.folio.services.finance.transaction;
+
+import io.vertx.core.Future;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.folio.models.InvoiceWorkflowDataHolder;
+import org.folio.rest.acq.model.finance.Encumbrance;
+import org.folio.rest.acq.model.finance.Transaction;
+import org.folio.rest.acq.model.finance.TransactionCollection;
+import org.folio.rest.core.RestClient;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.core.models.RequestEntry;
+import org.folio.rest.jaxrs.model.FundDistribution;
+import org.folio.rest.jaxrs.model.Invoice;
+import org.folio.rest.jaxrs.model.InvoiceLine;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.folio.invoices.utils.HelperUtils.encodeQuery;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@DisplayName("EncumbranceService should :")
+@ExtendWith(VertxExtension.class)
+public class EncumbranceServiceTest {
+
+  @Mock
+  RequestContext requestContext;
+
+  @Mock
+  RestClient restClient;
+
+  private EncumbranceService encumbranceService;
+  private AutoCloseable mockitoMocks;
+
+
+  @BeforeEach
+  void init() {
+    mockitoMocks = MockitoAnnotations.openMocks(this);
+    BaseTransactionService transactionService = new BaseTransactionService(restClient);
+    OrderTransactionSummaryService orderTransactionSummaryService = new OrderTransactionSummaryService(restClient);
+    encumbranceService = new EncumbranceService(transactionService, orderTransactionSummaryService);
+  }
+
+  @AfterEach
+  void resetMocks() throws Exception {
+    mockitoMocks.close();
+  }
+
+  @Test
+  @DisplayName("update encumbrance links if needed when an invoice line is created")
+  void shouldUpdateEncumbranceLinksWhenAnInvoiceLineIsCreated(VertxTestContext vertxTestContext) {
+    String currentFiscalYearId = UUID.randomUUID().toString();
+    String pastFiscalYearId = UUID.randomUUID().toString();
+    String poLineId = UUID.randomUUID().toString();
+    String fundId = UUID.randomUUID().toString();
+    Invoice invoice = new Invoice()
+      .withFiscalYearId(pastFiscalYearId);
+    Transaction currentFYEncumbrance = new Transaction()
+      .withId(UUID.randomUUID().toString())
+      .withFiscalYearId(currentFiscalYearId)
+      .withFromFundId(fundId)
+      .withEncumbrance(new Encumbrance().withSourcePoLineId(poLineId));
+    Transaction pastFYEncumbrance = new Transaction()
+      .withId(UUID.randomUUID().toString())
+      .withFiscalYearId(pastFiscalYearId)
+      .withFromFundId(fundId)
+      .withEncumbrance(new Encumbrance().withSourcePoLineId(poLineId));
+    FundDistribution fd = new FundDistribution()
+      .withFundId(fundId)
+      .withEncumbrance(currentFYEncumbrance.getId());
+    InvoiceLine line = new InvoiceLine()
+      .withPoLineId(poLineId)
+      .withFundDistributions(List.of(fd));
+    List<InvoiceWorkflowDataHolder> holders = List.of(new InvoiceWorkflowDataHolder()
+      .withInvoiceLine(line)
+      .withFundDistribution(fd)
+      .withEncumbrance(currentFYEncumbrance));
+    TransactionCollection transactionCollection = new TransactionCollection();
+    transactionCollection.setTotalRecords(1);
+    transactionCollection.setTransactions(List.of(pastFYEncumbrance));
+
+    ArgumentCaptor<RequestEntry> requestEntryCaptor = ArgumentCaptor.forClass(RequestEntry.class);
+    when(restClient.get(requestEntryCaptor.capture(), any(), eq(requestContext)))
+      .thenReturn(Future.succeededFuture(transactionCollection));
+
+    Future<List<InvoiceWorkflowDataHolder>> future = encumbranceService.updateEncumbranceLinksForFiscalYear(invoice,
+      holders, requestContext);
+
+    vertxTestContext.assertComplete(future)
+      .onComplete(ar -> {
+        assertEquals(pastFYEncumbrance, holders.get(0).getEncumbrance());
+        assertEquals(pastFYEncumbrance.getId(), holders.get(0).getFundDistribution().getEncumbrance());
+        assertEquals(pastFYEncumbrance.getId(), holders.get(0).getInvoiceLine().getFundDistributions().get(0).getEncumbrance());
+
+        verify(restClient, times(1))
+          .get(any(RequestEntry.class), any(), eq(requestContext));
+
+        List<RequestEntry> requestEntries = requestEntryCaptor.getAllValues();
+        assertEquals("/finance/transactions", requestEntries.get(0).getBaseEndpoint());
+        String expectedQuery = String.format(
+          "transactionType==Encumbrance AND fiscalYearId==%s AND encumbrance.sourcePoLineId==(%s)", pastFiscalYearId,
+          poLineId);
+        assertEquals(encodeQuery(expectedQuery), requestEntries.get(0).getQueryParams().get("query"));
+
+        vertxTestContext.completeNow();
+      });
+  }
+
+  @Test
+  @DisplayName("update encumbrance links when invoice fiscal year is changed")
+  void updateEncumbranceLinksWhenInvoiceFiscalYearIsChanged(VertxTestContext vertxTestContext) {
+    String currentFiscalYearId = UUID.randomUUID().toString();
+    String pastFiscalYearId = UUID.randomUUID().toString();
+    String poLineId1 = UUID.randomUUID().toString();
+    String poLineId2 = UUID.randomUUID().toString();
+    String poLineId3 = UUID.randomUUID().toString();
+    String fundId1 = UUID.randomUUID().toString();
+    String fundId2 = UUID.randomUUID().toString();
+    String fundId3 = UUID.randomUUID().toString();
+    String fundId4 = UUID.randomUUID().toString();
+    Invoice newInvoice = new Invoice()
+      .withFiscalYearId(currentFiscalYearId);
+    Transaction currentFYEncumbrance1 = new Transaction()
+      .withId(UUID.randomUUID().toString())
+      .withFiscalYearId(currentFiscalYearId)
+      .withFromFundId(fundId1)
+      .withEncumbrance(new Encumbrance().withSourcePoLineId(poLineId1));
+    Transaction currentFYEncumbrance2 = new Transaction()
+      .withId(UUID.randomUUID().toString())
+      .withFiscalYearId(currentFiscalYearId)
+      .withFromFundId(fundId2)
+      .withEncumbrance(new Encumbrance().withSourcePoLineId(poLineId2));
+    Transaction currentFYEncumbrance3 = new Transaction()
+      .withId(UUID.randomUUID().toString())
+      .withFiscalYearId(currentFiscalYearId)
+      .withFromFundId(fundId3)
+      .withEncumbrance(new Encumbrance().withSourcePoLineId(poLineId3));
+    Transaction pastFYEncumbrance1 = new Transaction()
+      .withId(UUID.randomUUID().toString())
+      .withFiscalYearId(pastFiscalYearId)
+      .withFromFundId(fundId1)
+      .withEncumbrance(new Encumbrance().withSourcePoLineId(poLineId1));
+    Transaction pastFYEncumbrance2 = new Transaction()
+      .withId(UUID.randomUUID().toString())
+      .withFiscalYearId(pastFiscalYearId)
+      .withFromFundId(fundId2)
+      .withEncumbrance(new Encumbrance().withSourcePoLineId(poLineId2));
+    FundDistribution fd1 = new FundDistribution()
+      .withFundId(fundId1)
+      .withEncumbrance(currentFYEncumbrance1.getId());
+    FundDistribution fd2 = new FundDistribution()
+      .withFundId(fundId2)
+      .withEncumbrance(currentFYEncumbrance2.getId());
+    FundDistribution fd3 = new FundDistribution()
+      .withFundId(fundId3)
+      .withEncumbrance(currentFYEncumbrance3.getId());
+    FundDistribution fd4 = new FundDistribution()
+      .withFundId(fundId4);
+    InvoiceLine line1 = new InvoiceLine()
+      .withPoLineId(poLineId1)
+      .withFundDistributions(List.of(fd1));
+    InvoiceLine line2 = new InvoiceLine()
+      .withPoLineId(poLineId2)
+      .withFundDistributions(List.of(fd2));
+    InvoiceLine line3 = new InvoiceLine()
+      .withPoLineId(poLineId3)
+      .withFundDistributions(List.of(fd3));
+    InvoiceLine line4 = new InvoiceLine()
+      .withFundDistributions(List.of(fd4));
+    InvoiceWorkflowDataHolder holder1 = new InvoiceWorkflowDataHolder()
+      .withInvoice(newInvoice)
+      .withInvoiceLine(line1)
+      .withFundDistribution(fd1)
+      .withEncumbrance(currentFYEncumbrance1);
+    InvoiceWorkflowDataHolder holder2 = new InvoiceWorkflowDataHolder()
+      .withInvoice(newInvoice)
+      .withInvoiceLine(line2)
+      .withFundDistribution(fd2)
+      .withEncumbrance(currentFYEncumbrance2);
+    InvoiceWorkflowDataHolder holder3 = new InvoiceWorkflowDataHolder()
+      .withInvoice(newInvoice)
+      .withInvoiceLine(line3)
+      .withFundDistribution(fd3)
+      .withEncumbrance(currentFYEncumbrance3);
+    InvoiceWorkflowDataHolder holder4 = new InvoiceWorkflowDataHolder()
+      .withInvoice(newInvoice)
+      .withInvoiceLine(line4)
+      .withFundDistribution(fd4);
+    List<InvoiceWorkflowDataHolder> holders = List.of(holder1, holder2, holder3, holder4);
+    TransactionCollection transactionCollection = new TransactionCollection();
+    transactionCollection.setTotalRecords(2);
+    transactionCollection.setTransactions(List.of(pastFYEncumbrance1, pastFYEncumbrance2));
+
+    ArgumentCaptor<RequestEntry> requestEntryCaptor = ArgumentCaptor.forClass(RequestEntry.class);
+    when(restClient.get(requestEntryCaptor.capture(), any(), eq(requestContext)))
+      .thenReturn(Future.succeededFuture(transactionCollection));
+
+    Future<List<InvoiceLine>> future = encumbranceService.updateInvoiceLinesEncumbranceLinks(holders,
+      pastFiscalYearId, requestContext);
+
+    vertxTestContext.assertComplete(future)
+      .onComplete(ar -> {
+        List<InvoiceLine> updatedLines = ar.result();
+        assertThat(updatedLines, hasSize(3));
+
+        assertEquals(pastFYEncumbrance1.getId(), updatedLines.get(0).getFundDistributions().get(0).getEncumbrance());
+        assertEquals(pastFYEncumbrance2.getId(), updatedLines.get(1).getFundDistributions().get(0).getEncumbrance());
+        assertNull(updatedLines.get(2).getFundDistributions().get(0).getEncumbrance());
+
+        verify(restClient, times(1))
+          .get(any(RequestEntry.class), any(), eq(requestContext));
+
+        List<RequestEntry> requestEntries = requestEntryCaptor.getAllValues();
+        assertEquals("/finance/transactions", requestEntries.get(0).getBaseEndpoint());
+        String expectedQuery = String.format(
+          "transactionType==Encumbrance AND fiscalYearId==%s AND encumbrance.sourcePoLineId==(%s or %s or %s)",
+          pastFiscalYearId, poLineId1, poLineId2, poLineId3);
+        assertEquals(encodeQuery(expectedQuery), requestEntries.get(0).getQueryParams().get("query"));
+
+        vertxTestContext.completeNow();
+      });
+
+  }
+}


### PR DESCRIPTION
## Purpose
[MODINVOICE-474](https://issues.folio.org/browse/MODINVOICE-474) - Update the encumbrance when using a past fiscal year

## Approach
- When an invoice line is created based on an order line, update encumbrance links if needed to make sure they use encumbrances in the invoice fiscal year; remove the links when there is no matching encumbrance; avoid getting the encumbrances if updates are not needed (when all encumbrances match the invoice fiscal year)
- When an invoice fiscal year is changed, update the links similarly to make sure they only point to encumbrances in the invoice fiscal year
- Reused some existing code used during approval to update encumbrance links
- Take expense classes into account when matching holders and retrieved encumbrances (this was not done previously, during invoice approval)
- When cancelling an invoice, use the invoice fiscal year to look for encumbrances
- When cleaning up old encumbrances (when an invoice is approved), use the invoice fiscal year to look for encumbrances
- Moved most of the new code into `encumbranceService` to facilitate unit tests
- New and updated unit tests

Note: encumbrances themselves are never changed, only the links in the fund distributions.

Review together with the [integration test PR](https://github.com/folio-org/folio-integration-tests/pull/962).

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate action.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code are 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
