### PR TITLE
[MODINVOICE-473] Save invoice fiscal year if undefined after fund distribution changes

### DIFF
--- a/src/main/java/org/folio/invoices/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/invoices/utils/ErrorCodes.java
@@ -41,7 +41,7 @@ public enum ErrorCodes {
   CANNOT_ADD_ADJUSTMENTS("cannotAddAdjustment", "Prorated adjustment cannot be adde because it is not present on invoice level"),
   APPROVED_OR_PAID_INVOICE_DELETE_FORBIDDEN("approvedOrPaidInvoiceDeleteForbiddenError", "Approved or paid invoice can not be deleted"),
   BUDGET_NOT_FOUND("budgetNotFoundByFundId", "Budget not found by fundId"),
-  BUDGET_NOT_FOUND_USING_FISCAL_YEAR_ID("budgetNotFoundByFundIdAndFiscalYearId", "Budget not found by fund id and fiscal year id"),
+  BUDGET_NOT_FOUND_USING_FISCAL_YEAR_ID("budgetNotFoundByFundIdAndFiscalYearId", "Active budget not found by fund id and fiscal year id"),
   LEDGER_NOT_FOUND("ledgerNotFound", "Ledger not found"),
   FUND_CANNOT_BE_PAID("fundCannotBePaid", "Fund cannot be paid due to restrictions"),
   INACTIVE_EXPENSE_CLASS("inactiveExpenseClass", "Expense class is Inactive"),

--- a/src/main/java/org/folio/rest/impl/InvoiceLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/InvoiceLineHelper.java
@@ -107,19 +107,20 @@ public class InvoiceLineHelper extends AbstractHelper {
       .map(InvoiceLineCollection::getInvoiceLines);
   }
 
-  Future<InvoiceLineCollection> getInvoiceLineCollection(String endpoint) {
-    return invoiceLineService.getInvoiceLines(endpoint, buildRequestContext());
+  Future<InvoiceLineCollection> getInvoiceLineCollection(String endpoint, RequestContext requestContext) {
+    return invoiceLineService.getInvoiceLines(endpoint, requestContext);
   }
 
-  public Future<InvoiceLine> getInvoiceLine(String id) {
-    return invoiceLineService.getInvoiceLine(id, buildRequestContext());
+  public Future<InvoiceLine> getInvoiceLine(String id, RequestContext requestContext) {
+    return invoiceLineService.getInvoiceLine(id, requestContext);
   }
 
-  private Future<Void> updateOutOfSyncInvoiceLine(InvoiceLine invoiceLine, Invoice invoice) {
+  private Future<Void> updateOutOfSyncInvoiceLine(InvoiceLine invoiceLine, Invoice invoice,
+      boolean[] invoiceSerializationNeeded, RequestContext requestContext) {
     logger.info("Invoice line with id={} is out of date in storage and going to be updated", invoiceLine.getId());
     InvoiceLineHelper helper = new InvoiceLineHelper(okapiHeaders, ctx);
-    return helper.updateInvoiceLineToStorage(invoiceLine)
-      .compose(v -> updateInvoice(invoice, buildRequestContext()));
+    return helper.updateInvoiceLineToStorage(invoiceLine, requestContext)
+      .compose(v -> updateInvoice(invoice, invoiceSerializationNeeded, requestContext));
   }
 
   /**
@@ -167,32 +168,36 @@ public class InvoiceLineHelper extends AbstractHelper {
    * @return completable future with {@link InvoiceLine} on success or an exception if processing fails
    */
   public Future<InvoiceLine> getInvoiceLinePersistTotal(String id) {
-    // GET invoice-line from storage
-   return getInvoiceLine(id)
+    boolean[] invoiceSerializationNeeded = { false };
+    RequestContext requestContext = buildRequestContext();
+    return getInvoiceLine(id, requestContext)
       .compose(invoiceLineFromStorage ->
-        getInvoiceAndCheckProtection(invoiceLineFromStorage)
+        getInvoiceAndCheckProtection(invoiceLineFromStorage, requestContext)
           .compose(invoice -> {
             boolean isTotalOutOfSync = reCalculateInvoiceLineTotals(invoiceLineFromStorage, invoice);
             if (!isTotalOutOfSync) {
               return succeededFuture(invoiceLineFromStorage);
             }
-            return updateOutOfSyncInvoiceLine(invoiceLineFromStorage, invoice)
+            return updateOutOfSyncInvoiceLine(invoiceLineFromStorage, invoice, invoiceSerializationNeeded, requestContext)
+              .compose(v -> persistInvoiceIfNeeded(invoice, invoiceSerializationNeeded, requestContext))
               .map(v -> invoiceLineFromStorage);
           })
       )
       .onFailure(t -> logger.error("Failed to get an Invoice Line by id={}", id, t.getCause()));
   }
 
-  public Future<Void> updateInvoiceLineToStorage(InvoiceLine invoiceLine) {
-    return invoiceLineService.updateInvoiceLine(invoiceLine, buildRequestContext());
+  public Future<Void> updateInvoiceLineToStorage(InvoiceLine invoiceLine, RequestContext requestContext) {
+    return invoiceLineService.updateInvoiceLine(invoiceLine, requestContext);
   }
 
   public Future<Void> updateInvoiceLine(InvoiceLine invoiceLine, RequestContext requestContext) {
-    var invoiceLineFuture = getInvoiceLine(invoiceLine.getId());
-    var invoiceFuture = invoiceLineFuture.compose(invLine -> invoiceService.getInvoiceById(invoiceLine.getInvoiceId(), requestContext));
+    boolean[] invoiceSerializationNeeded = { false };
+    var invoiceLineFuture = getInvoiceLine(invoiceLine.getId(), requestContext);
+    var invoiceFuture = invoiceLineFuture.compose(invLine -> invoiceService.getInvoiceById(invoiceLine.getInvoiceId(),
+      requestContext));
 
     return invoiceFuture
-      .compose(invoice -> getInvoiceWorkflowDataHolders(invoice, invoiceLine, requestContext))
+      .compose(invoice -> getInvoiceWorkflowDataHolders(invoice, invoiceLine, invoiceSerializationNeeded, requestContext))
       .compose(holders -> budgetExpenseClassService.checkExpenseClasses(holders, requestContext))
       .map(holders -> {
         var invoice = invoiceFuture.result();
@@ -204,9 +209,12 @@ public class InvoiceLineHelper extends AbstractHelper {
         return null;
       })
       .compose(v -> protectionHelper.isOperationRestricted(invoiceFuture.result().getAcqUnitIds(), UPDATE))
-      .compose(ok -> applyAdjustmentsAndUpdateLine(invoiceLine, invoiceLineFuture.result(), invoiceFuture.result()))
+      .compose(ok -> applyAdjustmentsAndUpdateLine(invoiceLine, invoiceLineFuture.result(), invoiceFuture.result(),
+        invoiceSerializationNeeded, requestContext))
       .compose(ok -> updateOrderInvoiceRelationship(invoiceLine, invoiceLineFuture.result(), requestContext))
-      .compose(ok -> updateInvoicePoNumbers(invoiceFuture.result(), invoiceLine, invoiceLineFuture.result(), requestContext));
+      .compose(ok -> updateInvoicePoNumbers(invoiceFuture.result(), invoiceLine, invoiceLineFuture.result(),
+        invoiceSerializationNeeded, requestContext))
+      .compose(v -> persistInvoiceIfNeeded(invoiceFuture.result(), invoiceSerializationNeeded, requestContext));
   }
 
   private void unlinkEncumbranceFromChangedFunds(InvoiceLine invoiceLine, InvoiceLine invoiceLineFromStorage) {
@@ -256,21 +264,21 @@ public class InvoiceLineHelper extends AbstractHelper {
   }
 
   private Future<Void> applyAdjustmentsAndUpdateLine(InvoiceLine invoiceLine, InvoiceLine invoiceLineFromStorage,
-      Invoice invoice) {
+      Invoice invoice, boolean[] invoiceSerializationNeeded, RequestContext requestContext) {
     // Just persist updates if invoice is already finalized
     if (isPostApproval(invoice)) {
-      return updateInvoiceLineToStorage(invoiceLine);
+      return updateInvoiceLineToStorage(invoiceLine, requestContext);
     }
 
     // Re-apply prorated adjustments if available
-    return applyProratedAdjustments(invoiceLine, invoice).compose(affectedLines -> {
+    return applyProratedAdjustments(invoiceLine, invoice, requestContext).compose(affectedLines -> {
       // Recalculate totals before update which also indicates if invoice requires update
       calculateInvoiceLineTotals(invoiceLine, invoice);
       // Update invoice line in storage
-      return updateInvoiceLineToStorage(invoiceLine).compose(v -> {
+      return updateInvoiceLineToStorage(invoiceLine, requestContext).compose(v -> {
         // Trigger invoice update event only if this is required
         if (!affectedLines.isEmpty() || !areTotalsEqual(invoiceLine, invoiceLineFromStorage)) {
-          return updateInvoiceAndAffectedLines(invoice, affectedLines);
+          return updateInvoiceAndAffectedLines(invoice, affectedLines, invoiceSerializationNeeded, requestContext);
         } else {
           return succeededFuture(null);
         }
@@ -286,21 +294,26 @@ public class InvoiceLineHelper extends AbstractHelper {
    * @param lineId invoiceLine id to be deleted
    */
   public Future<Void> deleteInvoiceLine(String lineId) {
-    var invoiceFuture = getInvoicesIfExists(lineId);
-    var invoiceLineFuture = invoiceLineService.getInvoiceLine(lineId, buildRequestContext());
+    boolean[] invoiceSerializationNeeded = { false };
+    RequestContext requestContext = buildRequestContext();
+    var invoiceFuture = getInvoicesIfExists(lineId, requestContext);
+    var invoiceLineFuture = invoiceLineService.getInvoiceLine(lineId, requestContext);
 
     return CompositeFuture.join(invoiceFuture, invoiceLineFuture)
       .compose(cf -> protectionHelper.isOperationRestricted(invoiceFuture.result().getAcqUnitIds(), DELETE)
       .compose(v -> InvoiceRestrictionsUtil.checkIfInvoiceDeletionPermitted(invoiceFuture.result())))
-      .compose(invoiceHold -> orderService.deleteOrderInvoiceRelationIfLastInvoice(lineId, buildRequestContext())
-        .compose(v -> invoiceLineService.deleteInvoiceLine(lineId, buildRequestContext()))
-        .compose(v -> updateInvoiceAndLines(invoiceFuture.result(), buildRequestContext()))
-        .compose(v -> deleteInvoicePoNumbers(invoiceFuture.result(), invoiceLineFuture.result(), buildRequestContext())));
+      .compose(invoiceHold -> orderService.deleteOrderInvoiceRelationIfLastInvoice(lineId, requestContext)
+        .compose(v -> invoiceLineService.deleteInvoiceLine(lineId, requestContext))
+        .compose(v -> updateInvoiceAndLines(invoiceFuture.result(), invoiceSerializationNeeded, requestContext))
+        .compose(v -> deleteInvoicePoNumbers(invoiceFuture.result(), invoiceLineFuture.result(),
+          invoiceSerializationNeeded, requestContext))
+        .compose(v -> persistInvoiceIfNeeded(invoiceFuture.result(), invoiceSerializationNeeded, requestContext))
+      );
   }
 
-  private Future<Invoice> getInvoicesIfExists(String lineId) {
+  private Future<Invoice> getInvoicesIfExists(String lineId, RequestContext requestContext) {
     String query = QUERY_PARAM_START_WITH + lineId;
-    return invoiceService.getInvoices(query, 0, Integer.MAX_VALUE, buildRequestContext())
+    return invoiceService.getInvoices(query, 0, Integer.MAX_VALUE, requestContext)
       .compose(invoiceCollection -> {
       if (!invoiceCollection.getInvoices().isEmpty()) {
         return succeededFuture(invoiceCollection.getInvoices().get(0));
@@ -320,24 +333,27 @@ public class InvoiceLineHelper extends AbstractHelper {
    */
   public Future<InvoiceLine> createInvoiceLine(InvoiceLine invoiceLine) {
     RequestContext requestContext = new RequestContext(ctx, okapiHeaders);
+    boolean[] invoiceSerializationNeeded = { false };
     return invoiceService.getInvoiceById(invoiceLine.getInvoiceId(), requestContext)
       .map(invoice -> {
       validator.validateLineAdjustmentsOnCreate(invoiceLine, invoice);
       return invoice;
     })
       .map(this::checkIfInvoiceLineCreationAllowed)
-      .compose(invoice -> getInvoiceWorkflowDataHolders(invoice, invoiceLine, requestContext)
+      .compose(invoice -> getInvoiceWorkflowDataHolders(invoice, invoiceLine, invoiceSerializationNeeded, requestContext)
         .compose(holders -> budgetExpenseClassService.checkExpenseClasses(holders, requestContext))
         .compose(holders -> encumbranceService.updateEncumbranceLinksForFiscalYear(invoice, holders, requestContext))
         .map(holders -> invoice))
       .compose(invoice -> protectionHelper.isOperationRestricted(invoice.getAcqUnitIds(), ProtectedOperationType.CREATE)
         .map(v -> invoice))
-      .compose(invoice -> createInvoiceLine(invoiceLine, invoice)
+      .compose(invoice -> createInvoiceLine(invoiceLine, invoice, invoiceSerializationNeeded, requestContext)
         .compose(line -> orderService.createInvoiceOrderRelation(line, buildRequestContext())
           .recover(throwable -> {
             throw new HttpException(500, ORDER_INVOICE_RELATION_CREATE_FAILED.toError());
           })
-          .compose(v -> updateInvoicePoNumbers(invoice, line, null, buildRequestContext()))
+          .compose(v -> updateInvoicePoNumbers(invoice, line, null, invoiceSerializationNeeded,
+            requestContext))
+          .compose(v -> persistInvoiceIfNeeded(invoice, invoiceSerializationNeeded, requestContext))
           .map(v -> line)));
   }
 
@@ -348,8 +364,8 @@ public class InvoiceLineHelper extends AbstractHelper {
     return invoice;
   }
 
-  private Future<Invoice> getInvoiceAndCheckProtection(InvoiceLine invoiceLineFromStorage) {
-    return invoiceService.getInvoiceById(invoiceLineFromStorage.getInvoiceId(), buildRequestContext())
+  private Future<Invoice> getInvoiceAndCheckProtection(InvoiceLine invoiceLineFromStorage, RequestContext requestContext) {
+    return invoiceService.getInvoiceById(invoiceLineFromStorage.getInvoiceId(), requestContext)
       .compose(invoice -> protectionHelper.isOperationRestricted(invoice.getAcqUnitIds(), READ)
         .map(aVoid -> invoice));
   }
@@ -361,15 +377,18 @@ public class InvoiceLineHelper extends AbstractHelper {
    * @param invoice     associated {@link Invoice} object
    * @return completable future which might hold {@link InvoiceLine} on success or an exception if any issue happens
    */
-  private Future<InvoiceLine> createInvoiceLine(InvoiceLine invoiceLine, Invoice invoice) {
-    return invoiceLineService.generateLineNumber(invoice.getId(), buildRequestContext())
+  private Future<InvoiceLine> createInvoiceLine(InvoiceLine invoiceLine, Invoice invoice,
+      boolean[] invoiceSerializationNeeded, RequestContext requestContext) {
+    return invoiceLineService.generateLineNumber(invoice.getId(), requestContext)
       .onSuccess(invoiceLine::setInvoiceLineNumber)
       // First the prorated adjustments should be applied. In case there is any, it might require to update other lines
-      .compose(ok -> applyProratedAdjustments(invoiceLine, invoice))
+      .compose(ok -> applyProratedAdjustments(invoiceLine, invoice, requestContext))
       .compose(affectedLines -> {
         calculateInvoiceLineTotals(invoiceLine, invoice);
-        return invoiceLineService.createInvoiceLine(invoiceLine, buildRequestContext())
-          .compose(createdInvoiceLine -> updateInvoiceAndAffectedLines(invoice, affectedLines).map(v -> createdInvoiceLine));
+        return invoiceLineService.createInvoiceLine(invoiceLine, requestContext)
+          .compose(createdInvoiceLine -> updateInvoiceAndAffectedLines(invoice, affectedLines,
+              invoiceSerializationNeeded, requestContext)
+            .map(v -> createdInvoiceLine));
       });
   }
 
@@ -384,7 +403,8 @@ public class InvoiceLineHelper extends AbstractHelper {
    * @param invoice     associated {@link Invoice} record
    * @return list of other lines which are updated after applying prorated adjustment(s)
    */
-  private Future<List<InvoiceLine>> applyProratedAdjustments(InvoiceLine invoiceLine, Invoice invoice) {
+  private Future<List<InvoiceLine>> applyProratedAdjustments(InvoiceLine invoiceLine, Invoice invoice,
+      RequestContext requestContext) {
 
     if (adjustmentsService.getProratedAdjustments(invoice)
       .isEmpty()) {
@@ -393,7 +413,7 @@ public class InvoiceLineHelper extends AbstractHelper {
     invoiceLine.getAdjustments()
       .forEach(adjustment -> adjustment.setProrate(Adjustment.Prorate.NOT_PRORATED));
 
-    return getRelatedLines(invoiceLine).map(lines -> {
+    return getRelatedLines(invoiceLine, requestContext).map(lines -> {
       // Create new list adding current line as well
       List<InvoiceLine> allLines = new ArrayList<>(lines);
       allLines.add(invoiceLine);
@@ -413,61 +433,63 @@ public class InvoiceLineHelper extends AbstractHelper {
    * @param invoiceLine {@link InvoiceLine} record
    * @return list of all other invoice lines associated with the same invoice
    */
-  private Future<List<InvoiceLine>> getRelatedLines(InvoiceLine invoiceLine) {
+  private Future<List<InvoiceLine>> getRelatedLines(InvoiceLine invoiceLine, RequestContext requestContext) {
     String cql = String.format(QUERY_BY_INVOICE_ID, invoiceLine.getInvoiceId());
     if (invoiceLine.getId() != null) {
       cql = combineCqlExpressions("and", cql, "id<>" + invoiceLine.getId());
     }
     String endpoint = String.format(GET_INVOICE_LINES_BY_QUERY, Integer.MAX_VALUE, 0, getEndpointWithQuery(cql));
 
-    return getInvoiceLineCollection(endpoint).map(InvoiceLineCollection::getInvoiceLines);
+    return getInvoiceLineCollection(endpoint, requestContext).map(InvoiceLineCollection::getInvoiceLines);
   }
 
-  private Future<Void> updateInvoiceAndAffectedLines(Invoice invoice, List<InvoiceLine> lines) {
-    return persistInvoiceLines(invoice, lines)
-      .compose(v -> updateInvoice(invoice, buildRequestContext()))
+  private Future<Void> updateInvoiceAndAffectedLines(Invoice invoice, List<InvoiceLine> lines,
+      boolean[] invoiceSerializationNeeded, RequestContext requestContext) {
+    return persistInvoiceLines(invoice, lines, requestContext)
+      .compose(v -> updateInvoice(invoice, invoiceSerializationNeeded, requestContext))
       .recover(t -> {
         logger.error("Failed to update the invoice and other lines", t);
         throw new HttpException(500, FAILED_TO_UPDATE_INVOICE_AND_OTHER_LINES.toError());
       });
   }
 
-  private Future<Void> persistInvoiceLines(Invoice invoice, List<InvoiceLine> lines) {
+  private Future<Void> persistInvoiceLines(Invoice invoice, List<InvoiceLine> lines, RequestContext requestContext) {
     var futures = lines.stream()
       .map(invoiceLine -> {
         calculateInvoiceLineTotals(invoiceLine, invoice);
-        return this.updateInvoiceLineToStorage(invoiceLine);
+        return this.updateInvoiceLineToStorage(invoiceLine, requestContext);
       })
       .collect(toList());
 
     return GenericCompositeFuture.join(futures).mapEmpty();
   }
 
-  private Future<Void> updateInvoice(Invoice invoice, RequestContext requestContext) {
+  private Future<Void> updateInvoice(Invoice invoice, boolean[] invoiceSerializationNeeded,
+      RequestContext requestContext) {
     return invoiceService.recalculateTotals(invoice, requestContext)
-      .compose(isOutOfSync -> {
+      .map(isOutOfSync -> {
         if (Boolean.TRUE.equals(isOutOfSync)) {
           logger.info("The invoice with id={} is out of sync in storage and requires updates", invoice.getId());
-          InvoiceHelper helper = new InvoiceHelper(okapiHeaders, ctx);
-          return helper.updateInvoiceRecord(invoice);
+          invoiceSerializationNeeded[0] = true;
         } else {
           logger.info("The invoice with id={} is up to date in storage", invoice.getId());
-          return succeededFuture(null);
         }
+        return null;
       });
   }
 
-  public Future<Void> updateInvoiceAndLines(Invoice invoice, RequestContext requestContext) {
+  public Future<Void> updateInvoiceAndLines(Invoice invoice, boolean[] invoiceSerializationNeeded,
+      RequestContext requestContext) {
 
     // If no prorated adjustments, just update invoice details
     if (adjustmentsService.getProratedAdjustments(invoice).isEmpty()) {
-      return updateInvoice(invoice, requestContext);
+      return updateInvoice(invoice, invoiceSerializationNeeded, requestContext);
     }
 
     return getInvoiceLinesByInvoiceId(invoice.getId())
       .map(lines -> adjustmentsService.applyProratedAdjustments(lines, invoice))
-      .compose(lines -> persistInvoiceLines(invoice, lines))
-      .compose(ok -> updateInvoice(invoice, requestContext));
+      .compose(lines -> persistInvoiceLines(invoice, lines, requestContext))
+      .compose(ok -> updateInvoice(invoice, invoiceSerializationNeeded, requestContext));
 
   }
 
@@ -479,7 +501,7 @@ public class InvoiceLineHelper extends AbstractHelper {
    * @param requestContext - used to start new requests
    */
   private Future<Void> updateInvoicePoNumbers(Invoice invoice, InvoiceLine invoiceLine,
-      InvoiceLine invoiceLineFromStorage, RequestContext requestContext) {
+      InvoiceLine invoiceLineFromStorage, boolean[] invoiceSerializationNeeded, RequestContext requestContext) {
 
     if (!isPoNumbersUpdateNeeded(invoiceLineFromStorage, invoiceLine))
       return succeededFuture(null);
@@ -489,9 +511,12 @@ public class InvoiceLineHelper extends AbstractHelper {
       .compose(poLine -> orderService.getOrder(poLine.getPurchaseOrderId(), requestContext))
       .compose(order -> {
         if (invoiceLineFromStorage != null && invoiceLineFromStorage.getPoLineId() != null && invoiceLine.getPoLineId() == null) {
-          return removeInvoicePoNumber(order.getPoNumber(), order, invoice, invoiceLine, requestContext);
+          return removeInvoicePoNumber(order.getPoNumber(), order, invoice, invoiceLine, invoiceSerializationNeeded,
+            requestContext);
+        } else {
+          addInvoicePoNumber(order.getPoNumber(), invoice, invoiceSerializationNeeded);
+          return succeededFuture();
         }
-        return addInvoicePoNumber(order.getPoNumber(), invoice, requestContext);
       })
       .recover(throwable -> {
         logger.error("Failed to update invoice poNumbers", throwable);
@@ -504,15 +529,18 @@ public class InvoiceLineHelper extends AbstractHelper {
    * Delete the invoice's poNumbers field, following an invoice line removal.
    * @param invoice - the invoice of the modified invoice line
    * @param invoiceLine - the modified invoice line
+   * @param invoiceSerializationNeeded - boolean will be set to true if invoice needs to be saved
    * @param requestContext - used to start new requests
    */
-  private Future<Void> deleteInvoicePoNumbers(Invoice invoice, InvoiceLine invoiceLine, RequestContext requestContext) {
+  private Future<Void> deleteInvoicePoNumbers(Invoice invoice, InvoiceLine invoiceLine,
+      boolean[] invoiceSerializationNeeded, RequestContext requestContext) {
 
     if (invoiceLine.getPoLineId() == null)
       return succeededFuture(null);
     return orderLineService.getPoLine(invoiceLine.getPoLineId(), requestContext)
       .compose(poLine -> orderService.getOrder(poLine.getPurchaseOrderId(), requestContext))
-      .compose(order -> removeInvoicePoNumber(order.getPoNumber(), order, invoice, invoiceLine, requestContext))
+      .compose(order -> removeInvoicePoNumber(order.getPoNumber(), order, invoice, invoiceLine,
+        invoiceSerializationNeeded, requestContext))
       .recover(throwable -> {
         logger.error("Failed to update invoice poNumbers", throwable);
         throw new HttpException(500, FAILED_TO_UPDATE_PONUMBERS.toError());
@@ -531,32 +559,32 @@ public class InvoiceLineHelper extends AbstractHelper {
    * Removes orderPoNumber from the invoice's poNumbers field if needed.
    */
   private Future<Void> removeInvoicePoNumber(String orderPoNumber, CompositePurchaseOrder order,
-      Invoice invoice, InvoiceLine invoiceLine, RequestContext requestContext) {
+      Invoice invoice, InvoiceLine invoiceLine, boolean[] invoiceSerializationNeeded, RequestContext requestContext) {
 
     List<String> invoicePoNumbers = invoice.getPoNumbers();
     if (!invoicePoNumbers.contains(orderPoNumber))
       return succeededFuture(null);
     // check the other invoice lines to see if one of them is linking to the same order
     List<String> orderLineIds = order.getCompositePoLines().stream().map(CompositePoLine::getId).collect(toList());
-    return getRelatedLines(invoiceLine).compose(lines -> {
-      if (lines.stream().anyMatch(line -> orderLineIds.contains(line.getPoLineId()))) {
-        return succeededFuture(null);
-      } else {
+    return getRelatedLines(invoiceLine, requestContext).compose(lines -> {
+      if (lines.stream().noneMatch(line -> orderLineIds.contains(line.getPoLineId()))) {
         List<String> newNumbers = invoicePoNumbers.stream().filter(n -> !n.equals(orderPoNumber)).collect(toList());
-        return invoiceService.updateInvoice(invoice.withPoNumbers(newNumbers), requestContext);
+        invoice.setPoNumbers(newNumbers);
+        invoiceSerializationNeeded[0] = true;
       }
+      return succeededFuture(null);
     });
   }
 
   /**
    * Adds orderPoNumber to the invoice's poNumbers field if needed.
    */
-  private Future<Void> addInvoicePoNumber(String orderPoNumber, Invoice invoice, RequestContext requestContext) {
+  private void addInvoicePoNumber(String orderPoNumber, Invoice invoice, boolean[] invoiceSerializationNeeded) {
     List<String> invoicePoNumbers = invoice.getPoNumbers();
     if (invoicePoNumbers.contains(orderPoNumber))
-      return succeededFuture(null);
-    return invoiceService.updateInvoice(invoice.withPoNumbers(addPoNumberToList(invoicePoNumbers, orderPoNumber)),
-      requestContext);
+      return;
+    invoice.setPoNumbers(addPoNumberToList(invoicePoNumbers, orderPoNumber));
+    invoiceSerializationNeeded[0] = true;
   }
 
   private List<String> addPoNumberToList(List<String> numbers, String newNumber) {
@@ -571,17 +599,43 @@ public class InvoiceLineHelper extends AbstractHelper {
     return newNumbers;
   }
 
-  private Future<List<InvoiceWorkflowDataHolder>> getInvoiceWorkflowDataHolders(Invoice invoice, InvoiceLine invoiceLine, RequestContext requestContext) {
+  private Future<List<InvoiceWorkflowDataHolder>> getInvoiceWorkflowDataHolders(Invoice invoice, InvoiceLine invoiceLine,
+      boolean[] invoiceSerializationNeeded, RequestContext requestContext) {
     List<InvoiceLine> lines = new ArrayList<>();
     lines.add(invoiceLine);
 
     List<InvoiceWorkflowDataHolder> dataHolders = holderBuilder.buildHoldersSkeleton(lines, invoice);
     return holderBuilder.withFunds(dataHolders, requestContext)
-        .compose(holders -> holderBuilder.withLedgers(holders, requestContext))
-        .compose(holders -> holderBuilder.withBudgets(holders, requestContext))
-        .compose(holders -> holderBuilder.withFiscalYear(holders, requestContext))
-        .compose(holders -> holderBuilder.withEncumbrances(holders, requestContext))
-        .compose(holders -> holderBuilder.withExpenseClasses(holders, requestContext))
-        .compose(holders -> holderBuilder.withExchangeRate(holders, requestContext));
+      .compose(holders -> holderBuilder.withLedgers(holders, requestContext))
+      .compose(holders -> holderBuilder.withBudgets(holders, requestContext))
+      .map(holderBuilder::checkMultipleFiscalYears)
+      .compose(holders -> holderBuilder.withFiscalYear(holders, requestContext))
+      .map(holders -> updateInvoiceFiscalYear(holders, invoiceSerializationNeeded))
+      .compose(holders -> holderBuilder.withEncumbrances(holders, requestContext))
+      .compose(holders -> holderBuilder.withExpenseClasses(holders, requestContext))
+      .compose(holders -> holderBuilder.withExchangeRate(holders, requestContext));
+  }
+
+  private List<InvoiceWorkflowDataHolder> updateInvoiceFiscalYear(List<InvoiceWorkflowDataHolder> holders,
+      boolean[] invoiceSerializationNeeded) {
+    if (holders.isEmpty())
+      return holders;
+    Invoice invoice = holders.get(0).getInvoice();
+    if (invoice.getFiscalYearId() != null)
+      return holders;
+    logger.info("Invoice fiscal year updated based on the invoice line, invoiceLineId={}",
+      holders.get(0).getInvoiceLine().getId());
+    invoice.setFiscalYearId(holders.get(0).getFiscalYear().getId());
+    invoiceSerializationNeeded[0] = true;
+    return holders;
+  }
+
+  private Future<Void> persistInvoiceIfNeeded(Invoice invoice, boolean[] invoiceSerializationNeeded,
+      RequestContext requestContext) {
+    if (invoiceSerializationNeeded[0]) {
+      return invoiceService.updateInvoice(invoice, requestContext);
+    } else {
+      return succeededFuture(null);
+    }
   }
 }

--- a/src/main/java/org/folio/services/finance/budget/BudgetService.java
+++ b/src/main/java/org/folio/services/finance/budget/BudgetService.java
@@ -31,7 +31,7 @@ public class BudgetService {
 
   private static final String BUDGETS_ENDPOINT = resourcesPath(BUDGETS);
   private static final String ACTIVE_BUDGET_ENDPOINT = "/finance/funds/{id}/budget";
-  private static final String QUERY_BY_FUND_ID_AND_FISCAL_YEAR_ID = "fundId==%s and fiscalYearId==%s";
+  private static final String QUERY_BY_FUND_ID_AND_FISCAL_YEAR_ID = "budgetStatus==Active AND fundId==%s AND fiscalYearId==%s";
 
   private final RestClient restClient;
 

--- a/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
@@ -1068,8 +1068,9 @@ public class InvoicesApiTest extends ApiTestBase {
 
   @Test
   void testTransitionFromOpenToApprovedWithMultipleFiscalYears() {
-    Invoice reqData = getMockAsJson(OPEN_INVOICE_SAMPLE_PATH).mapTo(Invoice.class);
-    String invoiceId = reqData.getId();
+    Invoice invoice = getMockAsJson(OPEN_INVOICE_SAMPLE_PATH).mapTo(Invoice.class);
+    invoice.setFiscalYearId(null);
+    String invoiceId = invoice.getId();
 
     InvoiceLine invoiceLine1 = getMinimalContentInvoiceLine(invoiceId);
 
@@ -1128,9 +1129,9 @@ public class InvoicesApiTest extends ApiTestBase {
     addMockEntry(BUDGETS, JsonObject.mapFrom(budget2));
     addMockEntry(FUNDS, JsonObject.mapFrom(fund2));
 
-    reqData.setStatus(Invoice.Status.APPROVED);
+    invoice.setStatus(Invoice.Status.APPROVED);
 
-    String jsonBody = JsonObject.mapFrom(reqData).encode();
+    String jsonBody = JsonObject.mapFrom(invoice).encode();
     Headers headers = prepareHeaders(X_OKAPI_URL, X_OKAPI_TENANT, X_OKAPI_TOKEN, X_OKAPI_USER_ID);
     Errors errors = verifyPut(String.format(INVOICE_ID_PATH, invoiceId), jsonBody, headers, "", 422)
       .as(Errors.class);

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -1770,7 +1770,7 @@ public class MockServer {
           fiscalYearId = extractIdsFromQuery("fiscalYearId", "==", query).get(0);
         }
 
-        if (query.startsWith("fundId==")) {
+        if (query.contains("fundId==")) {
           ids = extractIdsFromQuery("fundId", "==", query);
         }
 

--- a/src/test/java/org/folio/services/finance/budget/BudgetServiceTest.java
+++ b/src/test/java/org/folio/services/finance/budget/BudgetServiceTest.java
@@ -93,7 +93,7 @@ public class BudgetServiceTest {
     BudgetCollection budgetCollection = new BudgetCollection()
       .withBudgets(List.of(budget))
       .withTotalRecords(1);
-    String query = String.format("fundId==%s and fiscalYearId==%s", fundId, invoiceFiscalYearId);
+    String query = String.format("budgetStatus==Active AND fundId==%s AND fiscalYearId==%s", fundId, invoiceFiscalYearId);
     ArgumentCaptor<RequestEntry> requestEntryCaptor = ArgumentCaptor.forClass(RequestEntry.class);
     when(restClient.get(requestEntryCaptor.capture(), any(), any()))
       .thenReturn(Future.succeededFuture(budgetCollection));

--- a/src/test/resources/mockdata/invoices/26f195ec-df57-11eb-ba80-0242ac130004.json
+++ b/src/test/resources/mockdata/invoices/26f195ec-df57-11eb-ba80-0242ac130004.json
@@ -1,5 +1,5 @@
 {
-  "id": "8d3881f6-dd93-46f0-b29d-1c36bdb5c9f9",
+  "id": "26f195ec-df57-11eb-ba80-0242ac130004",
   "accountingCode": "2556",
   "adjustments": [
     {
@@ -56,5 +56,6 @@
     "AB268758XYZ"
   ],
   "vendorId": "168f8a63-d612-406e-813f-c7527f241ac3",
-  "manualPayment": true
+  "manualPayment": true,
+  "fiscalYearId": "78110b4e-2f8e-4eef-81ee-3058c0c7a9ee"
 }

--- a/src/test/resources/mockdata/invoices/52fd6ec7-ddc3-4c53-bc26-2779afc27136.json
+++ b/src/test/resources/mockdata/invoices/52fd6ec7-ddc3-4c53-bc26-2779afc27136.json
@@ -18,5 +18,6 @@
     "228D126"
   ],
   "vendorId": "168f8a63-d612-406e-813f-c7527f241ac3",
-  "manualPayment": true
+  "manualPayment": true,
+  "fiscalYearId": "78110b4e-2f8e-4eef-81ee-3058c0c7a9ee"
 }


### PR DESCRIPTION
## Purpose
[MODINVOICE-473](https://issues.folio.org/browse/MODINVOICE-473) - Save invoice fiscal year if it is undefined after any fund distribution change

## Approach
- Save fiscal year id in invoice object after getting the fiscal years
- Save invoice at the end if needed
- Refactoring to avoid saving the invoice several times for the same request (previously it could have been saved twice; with the addition of the fiscal year change it could have been 3 times without refactoring)
- Avoid recreating the request context several times in the same request in `InvoiceLineHelper`
- When getting budgets for a past fiscal year, select active budgets (invoice approval will only work for active budgets)
- New and updated unit tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate action.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code are 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
