### PR TITLE
[MODINVOICE-478] Prevent conflicts when saving multiple invoice lines with data import

### DIFF
--- a/src/main/java/org/folio/invoices/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/invoices/utils/ErrorCodes.java
@@ -61,7 +61,8 @@ public enum ErrorCodes {
   MULTIPLE_FISCAL_YEARS("multipleFiscalYears", "Multiple fiscal years are used with the funds %s and %s."),
   COULD_NOT_FIND_VALID_FISCAL_YEAR("couldNotFindValidFiscalYear", "Could not find any valid fiscal year with a budget for all funds in the invoice"),
   MORE_THAN_ONE_FISCAL_YEAR_SERIES("moreThanOneFiscalYearSeries", "Fund distributions cannot reference more than one fiscal year series. Please edit fund distributions so they all come from the same fiscal year series."),
-  CANNOT_RESET_INVOICE_FISCAL_YEAR("cannotResetInvoiceFiscalYear", "Invoice fiscal year cannot be set to null if it was previously defined");
+  CANNOT_RESET_INVOICE_FISCAL_YEAR("cannotResetInvoiceFiscalYear", "Invoice fiscal year cannot be set to null if it was previously defined"),
+  ERROR_CREATING_INVOICE_LINE("errorCreatingInvoiceLine", "Error creating invoice line");
 
   private final String code;
   private final String description;

--- a/src/main/java/org/folio/invoices/utils/ResourcePathResolver.java
+++ b/src/main/java/org/folio/invoices/utils/ResourcePathResolver.java
@@ -14,7 +14,7 @@ public class ResourcePathResolver {
   public static final String ACQUISITIONS_MEMBERSHIPS = "acquisitionsMemberships";
   public static final String INVOICES = "invoices";
   public static final String INVOICE_LINES = "invoiceLines";
-  public static final String COMPOSITE_ORDER = "compositeOrder";
+  public static final String COMPOSITE_ORDERS = "compositeOrders";
   public static final String ORDER_LINES = "orderLines";
   public static final String ORDER_INVOICE_RELATIONSHIP = "orderInvoiceRelationship";
   public static final String VOUCHER_LINES = "voucherLines";
@@ -56,7 +56,7 @@ public class ResourcePathResolver {
     apis.put(ACQUISITIONS_UNITS, "/acquisitions-units-storage/units");
     apis.put(ACQUISITIONS_MEMBERSHIPS, "/acquisitions-units-storage/memberships");
     apis.put(INVOICES, "/invoice-storage/invoices");
-    apis.put(COMPOSITE_ORDER, "/orders/composite-orders");
+    apis.put(COMPOSITE_ORDERS, "/orders/composite-orders");
     apis.put(INVOICE_LINES, "/invoice-storage/invoice-lines");
     apis.put(INVOICE_LINE_NUMBER, "/invoice-storage/invoice-line-number");
     apis.put(ORDER_LINES, "/orders/order-lines");

--- a/src/main/java/org/folio/rest/impl/InvoiceHelper.java
+++ b/src/main/java/org/folio/rest/impl/InvoiceHelper.java
@@ -24,14 +24,17 @@ import static org.folio.services.voucher.VoucherCommandService.VOUCHER_NUMBER_PR
 import static org.folio.utils.UserPermissionsUtil.verifyUserHasAssignPermission;
 import static org.folio.utils.UserPermissionsUtil.verifyUserHasManagePermission;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -39,6 +42,10 @@ import javax.money.MonetaryAmount;
 import javax.money.convert.ConversionQuery;
 import javax.money.convert.CurrencyConversion;
 import javax.money.convert.ExchangeRateProvider;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
@@ -53,8 +60,11 @@ import org.folio.models.InvoiceWorkflowDataHolder;
 import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.acq.model.Organization;
 import org.folio.rest.acq.model.finance.ExpenseClass;
+import org.folio.rest.acq.model.finance.FiscalYear;
 import org.folio.rest.acq.model.finance.Fund;
 import org.folio.rest.acq.model.orders.CompositePoLine;
+import org.folio.rest.acq.model.orders.PoLine;
+import org.folio.rest.acq.model.orders.PurchaseOrder;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.Adjustment;
 import org.folio.rest.jaxrs.model.Error;
@@ -83,6 +93,9 @@ import org.folio.services.invoice.InvoiceFiscalYearsService;
 import org.folio.services.invoice.InvoiceLineService;
 import org.folio.services.invoice.InvoicePaymentService;
 import org.folio.services.invoice.InvoiceService;
+import org.folio.services.order.OrderLineService;
+import org.folio.services.order.OrderService;
+import org.folio.services.validator.InvoiceLineValidator;
 import org.folio.services.validator.InvoiceValidator;
 import org.folio.services.voucher.VoucherCommandService;
 import org.folio.services.voucher.VoucherService;
@@ -140,6 +153,10 @@ public class InvoiceHelper extends AbstractHelper {
   private VoucherLineService voucherLineService;
   @Autowired
   private InvoiceFiscalYearsService invoiceFiscalYearsService;
+  @Autowired
+  private OrderService orderService;
+  @Autowired
+  private OrderLineService orderLineService;
   private RequestContext requestContext;
 
   public InvoiceHelper(Map<String, String> okapiHeaders, Context ctx) {
@@ -149,7 +166,7 @@ public class InvoiceHelper extends AbstractHelper {
     SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
   }
 
-  public Future<Invoice> createInvoice(Invoice invoice, RequestContext requestContext) {
+  public Future<Invoice> createInvoice(Invoice invoice) {
     return Future.succeededFuture()
       .map(v -> {
         validator.validateIncomingInvoice(invoice);
@@ -157,9 +174,7 @@ public class InvoiceHelper extends AbstractHelper {
       })
       .compose(v -> validateAcqUnitsOnCreate(invoice.getAcqUnitIds()))
       .compose(v -> updateWithSystemGeneratedData(invoice))
-      .compose(v -> invoiceService.createInvoice(invoice, requestContext))
-      .map(Invoice::getId)
-      .map(invoice::withId);
+      .compose(v -> invoiceService.createInvoice(invoice, requestContext));
   }
 
   /**
@@ -278,6 +293,157 @@ public class InvoiceHelper extends AbstractHelper {
       .onFailure(t -> logger.error("Error getting fiscal years for invoice {}", invoiceId, t));
   }
 
+  public Future<CreateInvoiceAndLinesResult> createInvoiceAndLines(Invoice invoice, List<InvoiceLine> invoiceLines) {
+    CreateInvoiceAndLinesResult result = new CreateInvoiceAndLinesResult();
+
+    // Validate the lines before creating the invoice
+    Map<Integer, String> invoiceLinesErrors = validateInvoiceLines(invoiceLines);
+    InvoiceLineValidator invoiceLineValidator = new InvoiceLineValidator();
+    for (int i=0; i<invoiceLines.size(); i++) {
+      if (invoiceLinesErrors.get(i) != null) {
+        continue;
+      }
+      InvoiceLine invoiceLine = invoiceLines.get(i);
+      try {
+        invoiceLineValidator.validateLineAdjustmentsOnCreate(invoiceLine, invoice);
+      } catch (HttpException ex) {
+        invoiceLinesErrors.put(i+1, ex.getMessage() + ": " + JsonObject.mapFrom(ex.getErrors()));
+      }
+    }
+    result.invoiceLinesErrors = invoiceLinesErrors;
+    if (!invoiceLinesErrors.isEmpty()) {
+      return succeededFuture(result);
+    }
+
+    return createInvoice(invoice)
+      .map(newInvoice -> {
+        result.newInvoice = newInvoice;
+        return null;
+      })
+      .compose(v -> createInvoiceLines(result.newInvoice, invoiceLines, result))
+      .map(v -> result);
+  }
+
+  public static class CreateInvoiceAndLinesResult {
+    public Invoice newInvoice;
+    public List<InvoiceLine> newInvoiceLines;
+    public Map<Integer, String> invoiceLinesErrors;
+  }
+
+  private Future<CreateInvoiceAndLinesResult> createInvoiceLines(Invoice invoice, List<InvoiceLine> invoiceLines,
+      CreateInvoiceAndLinesResult result) {
+    // NOTE: this should be kept consistent with InvoiceLineHelper.createInvoiceLine()
+    // protectionHelper.isOperationRestricted(acqUnitIds, ProtectedOperationType.CREATE) has already been called at this point
+    return getInvoiceWorkflowDataHolders(invoice, invoiceLines, requestContext)
+      .compose(holders -> budgetExpenseClassService.checkExpenseClasses(holders, requestContext))
+      .compose(holders -> generateNewInvoiceLineNumbers(invoice.getId(), invoiceLines)
+        .map(newInvoice -> {
+          result.newInvoice = newInvoice;
+          updateInvoiceFiscalYear(newInvoice, holders);
+          return holders;
+        }))
+      .compose(holders -> encumbranceService.updateEncumbranceLinksForFiscalYear(result.newInvoice, holders, requestContext)
+      .map(v -> {
+        adjustmentsService.processProratedAdjustments(invoiceLines, result.newInvoice);
+        invoiceService.recalculateTotals(result.newInvoice, invoiceLines);
+        return null;
+      })
+      .compose(v -> invoiceLineService.createInvoiceLines(invoiceLines, requestContext))
+      .map(newInvoiceLines -> {
+        result.newInvoiceLines = newInvoiceLines;
+        return null;
+      })
+      .compose(v -> getPurchaseOrders(result.newInvoiceLines))
+      .compose(pos -> createInvoiceOrderRelations(result.newInvoice.getId(), pos)
+        .map(v -> {
+          updateInvoicePoNumbers(result.newInvoice, pos);
+          return null;
+        }))
+      .compose(v -> invoiceService.updateInvoice(result.newInvoice, requestContext))
+      .map(v -> result))
+      .onFailure(t -> logger.error("Error when creating invoice lines", t));
+  }
+
+  public Map<Integer, String> validateInvoiceLines(List<InvoiceLine> invoiceLines) {
+    Map<Integer, String> invoiceLinesErrors = new HashMap<>();
+    try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+      Validator schemaValidator = factory.getValidator();
+      for (int i = 0; i < invoiceLines.size(); i++) {
+        InvoiceLine invoiceLine = invoiceLines.get(i);
+        Set<ConstraintViolation<InvoiceLine>> violations = schemaValidator.validate(invoiceLine);
+        if (!violations.isEmpty()) {
+          String errorsAsString = violations.stream()
+            .map(v -> String.format("%s: %s", v.getPropertyPath().toString(), v.getMessage()))
+            .collect(Collectors.joining("; "));
+          invoiceLinesErrors.put(i + 1, errorsAsString);
+        }
+      }
+    }
+    return invoiceLinesErrors;
+  }
+
+  private Future<Invoice> generateNewInvoiceLineNumbers(String invoiceId, List<InvoiceLine> invoiceLines) {
+    // NOTE: currently we don't have a way to generate several numbers at a time like with order lines,
+    // and getting a new number saves the invoice each time; this could be optimized
+    List<Future<String>> futures = new ArrayList<>();
+    for (int i=0; i<invoiceLines.size(); i++) {
+      futures.add(invoiceLineService.generateLineNumber(invoiceId, requestContext));
+    }
+    Future<List<String>> futureNumbers = GenericCompositeFuture.join(futures)
+      .map(CompositeFuture::list);
+    return futureNumbers
+      .map(numbers -> {
+        numbers.sort(Comparator.comparing(Integer::valueOf));
+        for (int i=0; i<invoiceLines.size(); i++) {
+          invoiceLines.get(i).setInvoiceLineNumber(numbers.get(i));
+        }
+        return null;
+      })
+      .compose(v -> invoiceService.getInvoiceById(invoiceId, requestContext))
+      .onFailure(t -> logger.error("Error when generating new invoice line numbers", t));
+  }
+
+  private void updateInvoiceFiscalYear(Invoice invoice, List<InvoiceWorkflowDataHolder> holders) {
+    if (holders.isEmpty())
+      return;
+    if (invoice.getFiscalYearId() != null)
+      return;
+    holders.stream()
+      .map(InvoiceWorkflowDataHolder::getFiscalYear)
+      .filter(Objects::nonNull)
+      .map(FiscalYear::getId)
+      .filter(Objects::nonNull)
+      .findFirst()
+      .ifPresent(invoice::setFiscalYearId);
+  }
+
+  private Future<List<PurchaseOrder>> getPurchaseOrders(List<InvoiceLine> invoiceLines) {
+    List<String> poLineIds = invoiceLines.stream()
+      .map(InvoiceLine::getPoLineId)
+      .filter(Objects::nonNull)
+      .collect(toList());
+    if (poLineIds.isEmpty()) {
+      return succeededFuture(List.of());
+    }
+    return orderLineService.getPoLinesByIds(poLineIds, requestContext)
+      .map(poLines -> poLines.stream().map(PoLine::getPurchaseOrderId).distinct().collect(toList()))
+      .compose(poIds -> orderService.getOrdersByIds(poIds, requestContext))
+      .onFailure(t -> logger.error("Error when getting order lines and orders", t));
+  }
+
+  private Future<Void> createInvoiceOrderRelations(String invoiceId, List<PurchaseOrder> pos) {
+    if (pos.isEmpty())
+      return succeededFuture(null);
+    List<String> poIds = pos.stream().map(PurchaseOrder::getId).collect(toList());
+    return orderService.createInvoiceOrderRelations(invoiceId, poIds, requestContext)
+      .onFailure(t -> logger.error("Error when creating invoice order relations", t));
+  }
+
+  private void updateInvoicePoNumbers(Invoice invoice, List<PurchaseOrder> pos) {
+    List<String> numbers = pos.stream().map(PurchaseOrder::getPoNumber).collect(toList());
+    invoice.setPoNumbers(numbers);
+  }
+
 
   private Future<Void> handleExchangeRateChange(Invoice invoice, List<InvoiceLine> invoiceLines) {
     return getInvoiceWorkflowDataHolders(invoice, invoiceLines, requestContext)
@@ -322,7 +488,7 @@ public class InvoiceHelper extends AbstractHelper {
             return null;
           })
           .map(aVoid -> filterUpdatedLines(invoiceLines, updatedInvoiceLines))
-          .compose(lines -> invoiceLineService.persistInvoiceLines(lines, requestContext)))
+          .compose(lines -> invoiceLineService.updateInvoiceLines(lines, requestContext)))
         .compose(lines -> updateEncumbranceLinksWhenFiscalYearIsChanged(invoice, invoiceFromStorage, invoiceLines)));
   }
 
@@ -458,7 +624,7 @@ public class InvoiceHelper extends AbstractHelper {
       .compose(v -> getInvoiceWorkflowDataHolders(invoice, lines, requestContext))
       .compose(holders -> encumbranceService.updateInvoiceLinesEncumbranceLinks(holders,
           holders.get(0).getFiscalYear().getId(), requestContext)
-        .compose(linesToUpdate -> invoiceLineService.persistInvoiceLines(linesToUpdate, requestContext))
+        .compose(linesToUpdate -> invoiceLineService.updateInvoiceLines(linesToUpdate, requestContext))
         .map(v -> holders))
       .compose(holders -> budgetExpenseClassService.checkExpenseClasses(holders, requestContext))
       .compose(holders -> pendingPaymentWorkflowService.handlePendingPaymentsCreation(holders, invoice, requestContext))
@@ -844,7 +1010,7 @@ public class InvoiceHelper extends AbstractHelper {
     List<InvoiceWorkflowDataHolder> dataHolders = holderBuilder.buildHoldersSkeleton(lines, invoice);
     return holderBuilder.withEncumbrances(dataHolders, requestContext)
       .compose(holders -> encumbranceService.updateInvoiceLinesEncumbranceLinks(holders, newFiscalYearId, requestContext))
-      .compose(linesToUpdate -> invoiceLineService.persistInvoiceLines(linesToUpdate, requestContext));
+      .compose(linesToUpdate -> invoiceLineService.updateInvoiceLines(linesToUpdate, requestContext));
   }
 
   @VisibleForTesting

--- a/src/main/java/org/folio/rest/impl/InvoiceLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/InvoiceLineHelper.java
@@ -340,6 +340,7 @@ public class InvoiceLineHelper extends AbstractHelper {
    * @return completable future which {@link InvoiceLine} on success
    */
   public Future<InvoiceLine> createInvoiceLine(InvoiceLine invoiceLine) {
+    // NOTE: this should be kept consistent with InvoiceHelper.createInvoiceLines()
     RequestContext requestContext = new RequestContext(ctx, okapiHeaders);
     ILProcessing ilProcessing = new ILProcessing();
     ilProcessing.setInvoiceLine(invoiceLine);

--- a/src/main/java/org/folio/rest/impl/InvoicesImpl.java
+++ b/src/main/java/org/folio/rest/impl/InvoicesImpl.java
@@ -53,8 +53,7 @@ public class InvoicesImpl extends BaseApi implements org.folio.rest.jaxrs.resour
   public void postInvoiceInvoices(Invoice invoice, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     InvoiceHelper helper = new InvoiceHelper(okapiHeaders, vertxContext);
-    RequestContext requestContext = new RequestContext(vertxContext, okapiHeaders);
-    helper.createInvoice(invoice, requestContext)
+    helper.createInvoice(invoice)
       .onSuccess(invoiceWithId -> asyncResultHandler.handle(succeededFuture(helper.buildResponseWithLocation(String.format(INVOICE_LOCATION_PREFIX, invoiceWithId.getId()), invoiceWithId))))
       .onFailure(t -> {
         logger.error("Failed to create invoice ", t);

--- a/src/main/java/org/folio/services/invoice/InvoiceLineService.java
+++ b/src/main/java/org/folio/services/invoice/InvoiceLineService.java
@@ -1,6 +1,7 @@
 package org.folio.services.invoice;
 
 import static java.util.stream.Collectors.toList;
+import static org.folio.invoices.utils.ErrorCodes.ERROR_CREATING_INVOICE_LINE;
 import static org.folio.invoices.utils.ErrorCodes.INVOICE_LINE_NOT_FOUND;
 import static org.folio.invoices.utils.HelperUtils.INVOICE_ID;
 import static org.folio.invoices.utils.ResourcePathResolver.INVOICE_LINES;
@@ -12,12 +13,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.json.JsonObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.invoices.rest.exceptions.HttpException;
 import org.folio.invoices.utils.HelperUtils;
 import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
+import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Invoice;
 import org.folio.rest.jaxrs.model.InvoiceLine;
 import org.folio.rest.jaxrs.model.InvoiceLineCollection;
@@ -27,6 +33,8 @@ import org.folio.rest.jaxrs.model.SequenceNumber;
 import io.vertx.core.Future;
 
 public class InvoiceLineService {
+
+  private static final Logger log = LogManager.getLogger();
 
   private static final String INVOICE_LINES_ENDPOINT = resourcesPath(INVOICE_LINES);
   private static final String INVOICE_LINE_BY_ID_ENDPOINT = INVOICE_LINES_ENDPOINT + "/{id}";
@@ -71,12 +79,21 @@ public class InvoiceLineService {
         .filter(invoiceLine -> orderPoLineIds.contains(invoiceLine.getPoLineId())).collect(toList()));
   }
 
-  public Future<Void> persistInvoiceLines(List<InvoiceLine> lines,  RequestContext requestContext) {
+  public Future<List<InvoiceLine>> createInvoiceLines(List<InvoiceLine> lines,  RequestContext requestContext) {
+    List<Future<InvoiceLine>> futures = lines.stream()
+      .map(invoiceLine -> createInvoiceLine(invoiceLine, requestContext))
+      .collect(Collectors.toList());
+    return GenericCompositeFuture.join(futures)
+      .map(CompositeFuture::list);
+  }
+
+  public Future<Void> updateInvoiceLines(List<InvoiceLine> lines,  RequestContext requestContext) {
     var futures = lines.stream()
-      .map(invoiceLine -> persistInvoiceLine(invoiceLine, requestContext))
+      .map(invoiceLine -> updateInvoiceLine(invoiceLine, requestContext))
       .collect(Collectors.toList());
     return GenericCompositeFuture.join(futures).mapEmpty();
   }
+
   public Future<Void> updateInvoiceLine(InvoiceLine invoiceLine, RequestContext requestContext) {
     return restClient.put(resourceByIdPath(INVOICE_LINES, invoiceLine.getId()), invoiceLine, requestContext);
   }
@@ -90,14 +107,16 @@ public class InvoiceLineService {
       });
   }
 
-  private Future<Void> persistInvoiceLine(InvoiceLine invoiceLine,  RequestContext requestContext) {
-    RequestEntry requestEntry = new RequestEntry(INVOICE_LINE_BY_ID_ENDPOINT).withId(invoiceLine.getId());
-    return restClient.put(requestEntry, invoiceLine, requestContext);
-  }
-
   public Future<InvoiceLine> createInvoiceLine(InvoiceLine invoiceLine, RequestContext requestContext) {
     RequestEntry requestEntry = new RequestEntry(INVOICE_LINES_ENDPOINT);
-    return restClient.post(requestEntry, invoiceLine, InvoiceLine.class, requestContext);
+    return restClient.post(requestEntry, invoiceLine, InvoiceLine.class, requestContext)
+    .recover(throwable -> {
+      Parameter p1 = new Parameter().withKey("invoiceId").withValue(invoiceLine.getInvoiceId());
+      Parameter p2 = new Parameter().withKey("invoiceLineNumber").withValue(invoiceLine.getInvoiceLineNumber());
+      Error error = ERROR_CREATING_INVOICE_LINE.toError().withParameters(List.of(p1, p2));
+      log.error(JsonObject.mapFrom(error));
+      throw new HttpException(500, error);
+    });
   }
 
   public Future<Void> deleteInvoiceLine(String lineId, RequestContext requestContext) {

--- a/src/test/java/org/folio/dataimport/handlers/actions/CreateInvoiceEventHandlerTest.java
+++ b/src/test/java/org/folio/dataimport/handlers/actions/CreateInvoiceEventHandlerTest.java
@@ -136,7 +136,9 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
               new MappingRule().withPath("invoice.invoiceLines[].subTotal")
                 .withValue("MOA+203[2]"),
               new MappingRule().withPath("invoice.invoiceLines[].quantity")
-                .withValue("QTY+47[2]")
+                .withValue("QTY+47[2]"),
+              new MappingRule().withPath("invoice.invoiceLines[].description")
+                .withValue("{POL_title}; else IMD+L+050+[4]")
             )))))));
 
   private MappingProfile mappingProfileWithPoLineSyntax = new MappingProfile()
@@ -157,6 +159,8 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
               new MappingRule().withPath("invoice.invoiceLines[].poLineId")
                 .withName("poLineId")
                 .withValue("RFF+LI[2]; else {POL_NUMBER}"),
+              new MappingRule().withPath("invoice.invoiceLines[].quantity")
+                .withValue("QTY+47[2]"),
               new MappingRule().withPath("invoice.invoiceLines[].referenceNumbers[]")
                 .withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING)
                 .withName("referenceNumbers")
@@ -193,6 +197,10 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
               new MappingRule().withPath("invoice.invoiceLines[].poLineId")
                 .withName("poLineId")
                 .withValue("RFF+LI[2]; else {POL_NUMBER}"),
+              new MappingRule().withPath("invoice.invoiceLines[].quantity")
+                .withValue("QTY+47[2]"),
+              new MappingRule().withPath("invoice.invoiceLines[].description")
+                .withValue("{POL_title}; else IMD+L+050+[4]"),
               new MappingRule().withPath("invoice.invoiceLines[].fundDistributions[]")
                 .withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING)
                 .withValue("{POL_FUND_DISTRIBUTIONS}"),
@@ -219,6 +227,10 @@ public class CreateInvoiceEventHandlerTest extends ApiTestBase {
                 .withValue("RFF+LI[2]; else {POL_NUMBER}"),
               new MappingRule().withPath("invoice.invoiceLines[].subTotal")
                 .withValue("MOA+203[2]"),
+              new MappingRule().withPath("invoice.invoiceLines[].quantity")
+                .withValue("QTY+47[2]"),
+              new MappingRule().withPath("invoice.invoiceLines[].description")
+                .withValue("{POL_title}; else IMD+L+050+[4]"),
               new MappingRule().withPath("invoice.invoiceLines[].fundDistributions[]")
                 .withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING)
                 .withSubfields(List.of(new RepeatableSubfieldMapping()

--- a/src/test/resources/mockdata/compositeOrders/composite_orders.json
+++ b/src/test/resources/mockdata/compositeOrders/composite_orders.json
@@ -1,0 +1,30 @@
+{
+  "purchaseOrders": [
+    {
+      "id": "0cb6741d-4a00-47e5-a902-5678eb24478d",
+      "approved": true,
+      "assignedTo": "ab18897b-0e40-4f31-896b-9c9adc979a88",
+      "manualPo": false,
+      "notes": [
+        "ABCDEFGHIJKLMNO",
+        "ABCDEFGHIJKLMNOPQRST",
+        "ABCDEFGHIJKLMNOPQRSTUV"
+      ],
+      "poNumber": "228D126",
+      "orderType": "One-Time",
+      "reEncumber": false,
+      "vendor": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1",
+      "workflowStatus": "Pending",
+      "acqUnitIds": [
+
+      ],
+      "metadata": {
+        "createdDate": "2020-03-25T16:46:02.584+0000",
+        "createdByUserId": "440c89e3-7f6c-578a-9ea8-310dad23605e",
+        "updatedDate": "2020-03-25T16:46:02.584+0000",
+        "updatedByUserId": "440c89e3-7f6c-578a-9ea8-310dad23605e"
+      }
+    }
+  ],
+  "totalRecords": 1
+}

--- a/src/test/resources/mockdata/poLines/po_lines.json
+++ b/src/test/resources/mockdata/poLines/po_lines.json
@@ -1,0 +1,84 @@
+{
+  "poLines": [
+    {
+      "id": "0000edd1-b463-41ba-bf64-1b1d9f9d0001",
+      "purchaseOrderId" : "0cb6741d-4a00-47e5-a902-5678eb24478d",
+      "checkinItems": false,
+      "alerts": [],
+      "claims": [],
+      "collection": false,
+      "contributors": [],
+      "fundDistribution": [
+        {
+          "code": "USHIST",
+          "fundId": "388c0f7b-9fff-451c-b300-6509e443bef5",
+          "distributionType": "percentage",
+          "value": 80.0,
+          "encumbrance": "eb506834-6c70-4239-8d1a-6414a5b08ac3"
+        }
+      ],
+      "isPackage": false,
+      "locations": [],
+      "paymentStatus": "Pending",
+      "poLineNumber": "010170-01",
+      "receiptStatus": "Pending",
+      "reportingCodes": [],
+      "rush": false,
+      "titleOrPackage": "polTitle-1",
+      "vendorDetail": {
+        "instructions": "ABCDEFG",
+        "referenceNumbers": [
+          {
+            "refNumber": "C6546362",
+            "refNumberType": "Vendor title number"
+          }
+        ]
+      }
+    },
+    {
+      "id": "0000edd1-b463-41ba-bf64-1b1d9f9d0003",
+      "purchaseOrderId" : "0cb6741d-4a00-47e5-a902-5678eb24478d",
+      "checkinItems": false,
+      "alerts": [],
+      "claims": [],
+      "collection": false,
+      "contributors": [],
+      "fundDistribution": [
+        {
+          "code": "USHIST",
+          "fundId": "388c0f7b-9fff-451c-b300-6509e443bef5",
+          "distributionType": "percentage",
+          "value": 70.0,
+          "encumbrance": "eb506834-6c70-4239-8d1a-6414a5b08ac3",
+          "expenseClassId" : "5b5ebe3a-cf8b-4f16-a880-46873ef21388"
+        },
+        {
+          "code": "EUHIST",
+          "fundId": "55f48dc6-efa7-4cfe-bc7c-4786efe493e3",
+          "distributionType": "amount",
+          "value": 12.34,
+          "encumbrance": "fb506834-6c70-4239-8d1a-6414a5b08ac3",
+          "expenseClassId" : "6e6ed3c9-d959-4c91-a436-6076fb373816"
+        }
+      ],
+      "isPackage": false,
+      "locations": [],
+      "paymentStatus": "Pending",
+      "poLineNumber": "010170-03",
+      "receiptStatus": "Pending",
+      "reportingCodes": [],
+      "rush": false,
+      "titleOrPackage": "polTitle-3",
+      "vendorDetail": {
+        "instructions": "ABCDEFG",
+        "referenceNumbers": [
+          {
+            "refNumber": "E9498296",
+            "refNumberType": "Vendor title number"
+          }
+        ]
+      }
+    }
+  ],
+  "totalRecords": 2
+}


### PR DESCRIPTION
## Purpose
[MODINVOICE-478](https://issues.folio.org/browse/MODINVOICE-478) - Data import saving invoice lines in parallel can cause conflicts when invoices are updated

## Approach
New implementation to save invoice and invoice lines with data import.
There will no longer be potential conflicts when the invoice is updated, which happens several times in the process.
Line creations are processed together, which should make the whole operation significantly faster.
Error reporting is a little different: some (internal) errors that were previously reported with a line number will no longer be associated with a number. Other errors (for validation) will be better reported and will prevent the creation of the invoice and lines.

#### TODOS and Open Questions
TODO: Integration tests, especially `data-import/src/main/resources/folijet/data-import/features/import-edi-invoice.feature`. I was not able to test it because I could not get Kafka messages to be sent to IDEA from mod-data-import.
Also, we should check that error reporting still matches user expectations.

## Learning
I learned a way to validate objects with their Json schema. We should do that every time we don't get the objects directly with the API (such as when using Kafka).

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate action.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code are 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
