### PR TITLE
[MODINVOICE-501] Create necessary missed permissions that used in UI

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -692,6 +692,16 @@
       "description": "Delete an existing Invoice"
     },
     {
+      "permissionName": "invoice.item.approve",
+      "displayName": "Invoice - approve an existing Invoice",
+      "description": "Approve an existing Invoice"
+    },
+    {
+      "permissionName": "invoice.item.pay",
+      "displayName": "Invoice - pay an existing Invoice",
+      "description": "Pay an existing Invoice"
+    },
+    {
       "permissionName": "invoice.invoice-lines.collection.get",
       "displayName": "Invoice Line - get collection of Invoice lines",
       "description": "Get collection of Invoice lines"
@@ -1013,6 +1023,8 @@
         "invoice.invoices.item.post",
         "invoice.invoices.item.put",
         "invoice.invoices.item.delete",
+        "invoice.item.approve",
+        "invoice.item.pay",
         "invoice.invoice-lines.collection.get",
         "invoice.invoice-lines.item.get",
         "invoice.invoice-lines.item.post",


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODINVOICE-501
Permissions: invoice.item.approve, invoice.item.pay are used in UI but not created in module descriptor.
In this PR we are declaring them in module descriptor and they will be automatically created