### PR TITLE
[MODINVOICE-514] - Uninformative error in invoice payment due to usernot linked to the Purchase Order's acquisition unit

### DIFF
--- a/src/main/java/org/folio/invoices/utils/ErrorCodes.java
+++ b/src/main/java/org/folio/invoices/utils/ErrorCodes.java
@@ -13,6 +13,7 @@ public enum ErrorCodes {
   CANNOT_DELETE_INVOICE_LINE("cannotDeleteInvoiceLine", "Cannot delete invoice-line because invoice record associated with invoice-line not found"),
   INVALID_INVOICE_TRANSITION_ON_PAID_STATUS("invalidInvoiceStatusTransitionOnPaidStatus", "Cannot transition invoice to any other statuses when it is in Paid status"),
   PO_LINE_UPDATE_FAILURE("poLineUpdateFailure", "One or more purchase order line record(s) cannot be updated"),
+  USER_NOT_A_MEMBER_OF_THE_ACQ("userNotAMemberOfTheAcq", "User is not a member of the specified acquisitions group - operation is restricted"),
   VOUCHER_NOT_FOUND("voucherNotFound", "The voucher record is not found"),
   FUND_DISTRIBUTIONS_NOT_PRESENT("fundDistributionsNotPresent", "At least one fund distribution should present for every associated invoice line"),
   ACCOUNTING_CODE_NOT_PRESENT("accountingCodeNotPresent", "Invoice can not be approved, because it requires an accounting code to be export to accounting"),

--- a/src/main/java/org/folio/services/order/OrderLineService.java
+++ b/src/main/java/org/folio/services/order/OrderLineService.java
@@ -61,7 +61,7 @@ public class OrderLineService {
       .map(poLine -> updatePoLine(poLine, requestContext)
         .recover(cause -> {
           if (ExceptionUtil.matches(cause, USER_NOT_A_MEMBER_OF_THE_ACQ)) {
-            throw new HttpException(400, USER_NOT_A_MEMBER_OF_THE_ACQ.toError());
+            throw new HttpException(403, USER_NOT_A_MEMBER_OF_THE_ACQ.toError());
           } else {
             throw new HttpException(400, PO_LINE_UPDATE_FAILURE.toError());
           }

--- a/src/main/java/org/folio/utils/ExceptionUtil.java
+++ b/src/main/java/org/folio/utils/ExceptionUtil.java
@@ -13,7 +13,7 @@ public final class ExceptionUtil {
       var errors = httpException.getErrors();
       return errors != null && errors.getErrors() != null && errors.getErrors()
         .stream()
-        .anyMatch(error -> error.getCode().equals(errorCode.getCode()));
+        .anyMatch(error -> errorCode.getCode().equals(error.getCode()));
     }
     return false;
   }

--- a/src/main/java/org/folio/utils/ExceptionUtil.java
+++ b/src/main/java/org/folio/utils/ExceptionUtil.java
@@ -1,0 +1,20 @@
+package org.folio.utils;
+
+import org.folio.invoices.rest.exceptions.HttpException;
+import org.folio.invoices.utils.ErrorCodes;
+
+public final class ExceptionUtil {
+
+  private ExceptionUtil() {
+  }
+
+  public static boolean matches(Throwable cause, ErrorCodes errorCode) {
+    if (cause instanceof HttpException httpException) {
+      return httpException.getErrors().getErrors()
+        .stream()
+        .anyMatch(error -> error.getCode().equals(errorCode.getCode()));
+    }
+    return false;
+  }
+
+}

--- a/src/main/java/org/folio/utils/ExceptionUtil.java
+++ b/src/main/java/org/folio/utils/ExceptionUtil.java
@@ -10,7 +10,8 @@ public final class ExceptionUtil {
 
   public static boolean matches(Throwable cause, ErrorCodes errorCode) {
     if (cause instanceof HttpException httpException) {
-      return httpException.getErrors().getErrors()
+      var errors = httpException.getErrors();
+      return errors != null && errors.getErrors() != null && errors.getErrors()
         .stream()
         .anyMatch(error -> error.getCode().equals(errorCode.getCode()));
     }


### PR DESCRIPTION

## Purpose
https://issues.folio.org/browse/MODINVOICE-514

## Approach
Check if error from mod-orders matches the corresponding pattern and return different custom error.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate action.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code are 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
