### PR TITLE
[MODINVOICE-534] - Rethrow user not linked order's acquisition unit error

### DIFF
--- a/src/test/java/org/folio/services/order/OrderServiceTest.java
+++ b/src/test/java/org/folio/services/order/OrderServiceTest.java
@@ -138,13 +138,33 @@ public class OrderServiceTest {
   }
 
   @Test
-  void shouldRethrowUserNotAMemberOfTheAcq(VertxTestContext vertxTestContext) {
+  void shouldRethrowUserNotAMemberOfTheAcqWhenUpdatePoLine(VertxTestContext vertxTestContext) {
     // given
     doReturn(failedFuture(new HttpException(HttpStatus.HTTP_FORBIDDEN.toInt(), USER_NOT_A_MEMBER_OF_THE_ACQ.toError())))
       .when(restClient).put(any(RequestEntry.class), any(CompositePoLine.class), eq(requestContextMock));
 
     // when
     Future<Void> future = orderLineServiceInject.updateCompositePoLines(List.of(new CompositePoLine()), requestContextMock);
+
+    // then
+    vertxTestContext.assertFailure(future)
+      .onComplete(result -> {
+        HttpException httpException = (HttpException) result.cause();
+        assertEquals(HttpStatus.HTTP_FORBIDDEN.toInt(), httpException.getCode());
+        Error error = httpException.getErrors().getErrors().get(0);
+        assertEquals(USER_NOT_A_MEMBER_OF_THE_ACQ.getCode(), error.getCode());
+        vertxTestContext.completeNow();
+      });
+  }
+
+  @Test
+  void shouldRethrowUserNotAMemberOfTheAcqWhenGetPoLine(VertxTestContext vertxTestContext) {
+    // given
+    doReturn(failedFuture(new HttpException(HttpStatus.HTTP_FORBIDDEN.toInt(), USER_NOT_A_MEMBER_OF_THE_ACQ.toError())))
+      .when(restClient).get(any(RequestEntry.class), eq(CompositePoLine.class), eq(requestContextMock));
+
+    // when
+    Future<CompositePoLine> future = orderLineServiceInject.getPoLine("id", requestContextMock);
 
     // then
     vertxTestContext.assertFailure(future)


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODINVOICE-534

## Approach
Rethrow `userNotAMemberOfTheAcq` in the same way as it was done in scope of https://folio-org.atlassian.net/browse/MODINVOICE-514

#### TODOS and Open Questions

## Learning

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate action.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code are 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
