### PR TITLE
MODINVOSTO-172 Cannot search for voucher by number after editing vouc…

### DIFF
--- a/src/main/java/org/folio/rest/impl/VoucherHelper.java
+++ b/src/main/java/org/folio/rest/impl/VoucherHelper.java
@@ -89,8 +89,8 @@ public class VoucherHelper extends AbstractHelper {
   public Future<Void> partialVoucherUpdate(String id, Voucher voucher, RequestContext requestContext) {
     return voucherService.partialVoucherUpdate(id, voucher, requestContext)
       .compose(update -> baseInvoiceService.updateVoucherNumberInInvoice(voucher ,requestContext))
-      .onSuccess(result-> System.out.println("voucher associate with the invoice is changed "))
-      .onFailure(throwable ->  throwable.printStackTrace() );
+      .onSuccess(result -> logger.debug("Voucher associated with the invoice is changed"))
+      .onFailure(Throwable::printStackTrace);
   }
 
   public Future<VoucherCollection> getVouchers(int limit, int offset, String query, RequestContext requestContext) {

--- a/src/main/java/org/folio/rest/impl/VoucherHelper.java
+++ b/src/main/java/org/folio/rest/impl/VoucherHelper.java
@@ -89,8 +89,8 @@ public class VoucherHelper extends AbstractHelper {
   public Future<Void> partialVoucherUpdate(String id, Voucher voucher, RequestContext requestContext) {
     return voucherService.partialVoucherUpdate(id, voucher, requestContext)
       .compose(update -> baseInvoiceService.updateVoucherNumberInInvoice(voucher, requestContext))
-      .onSuccess(result -> logger.debug("The voucher number on the invoice has been updated"))
-      .onFailure(error -> logger.error("An error occurred", error));
+      .onSuccess(result -> logger.debug("The voucher number on the invoice has been updated, voucher id: {}", id))
+      .onFailure(error -> logger.error("An error occurred for updating the voucher with id: {}", id, error));
   }
 
   public Future<VoucherCollection> getVouchers(int limit, int offset, String query, RequestContext requestContext) {

--- a/src/main/java/org/folio/rest/impl/VoucherHelper.java
+++ b/src/main/java/org/folio/rest/impl/VoucherHelper.java
@@ -88,15 +88,14 @@ public class VoucherHelper extends AbstractHelper {
    */
   public Future<Void> partialVoucherUpdate(String id, Voucher voucher, RequestContext requestContext) {
     return voucherService.partialVoucherUpdate(id, voucher, requestContext)
-      .compose(update -> baseInvoiceService.updateVoucherNumberInInvoice(voucher ,requestContext))
-      .onSuccess(result -> logger.debug("Voucher associated with the invoice is changed"))
-      .onFailure(Throwable::printStackTrace);
+      .compose(update -> baseInvoiceService.updateVoucherNumberInInvoice(voucher, requestContext))
+      .onSuccess(result -> logger.debug("The voucher number on the invoice has been updated"))
+      .onFailure(error -> logger.error("An error occurred {}", error));
   }
 
   public Future<VoucherCollection> getVouchers(int limit, int offset, String query, RequestContext requestContext) {
     return voucherService.getVouchers(limit, offset, query, requestContext);
   }
-
 
   public Future<SequenceNumber> getStartValue(RequestContext requestContext) {
     return voucherNumberService.getStartValue(requestContext);

--- a/src/main/java/org/folio/rest/impl/VoucherHelper.java
+++ b/src/main/java/org/folio/rest/impl/VoucherHelper.java
@@ -90,7 +90,7 @@ public class VoucherHelper extends AbstractHelper {
     return voucherService.partialVoucherUpdate(id, voucher, requestContext)
       .compose(update -> baseInvoiceService.updateVoucherNumberInInvoice(voucher, requestContext))
       .onSuccess(result -> logger.debug("The voucher number on the invoice has been updated"))
-      .onFailure(error -> logger.error("An error occurred {}", error));
+      .onFailure(error -> logger.error("An error occurred", error));
   }
 
   public Future<VoucherCollection> getVouchers(int limit, int offset, String query, RequestContext requestContext) {

--- a/src/main/java/org/folio/services/invoice/BaseInvoiceService.java
+++ b/src/main/java/org/folio/services/invoice/BaseInvoiceService.java
@@ -200,7 +200,9 @@ public class BaseInvoiceService implements InvoiceService {
     return getInvoiceById(voucher.getInvoiceId(), requestContext)
       .compose(invoice -> {
         invoice.setVoucherNumber(voucher.getVoucherNumber());
-        return updateInvoice(invoice, requestContext);
+        return updateInvoice(invoice, requestContext)
+          .onSuccess(result -> logger.debug("updateVoucherNumberInInvoice:: VoucherNumber '{}' was set to invoice '{}', voucher.getVoucherNumber, invoice.getId"))
+          .onFailure(error -> logger.error("An error occurred", error));
       });
   }
 }

--- a/src/main/java/org/folio/services/invoice/BaseInvoiceService.java
+++ b/src/main/java/org/folio/services/invoice/BaseInvoiceService.java
@@ -30,6 +30,7 @@ import org.folio.rest.jaxrs.model.Invoice;
 import org.folio.rest.jaxrs.model.InvoiceCollection;
 import org.folio.rest.jaxrs.model.InvoiceLine;
 import org.folio.rest.jaxrs.model.SequenceNumber;
+import org.folio.rest.jaxrs.model.Voucher;
 import org.folio.services.adjusment.AdjustmentsService;
 import org.folio.services.order.OrderService;
 import org.javamoney.moneta.Money;
@@ -193,5 +194,13 @@ public class BaseInvoiceService implements InvoiceService {
     Double adjustmentsTotal = invoice.getAdjustmentsTotal();
     calculateTotals(invoice, lines);
     return !Objects.equals(adjustmentsTotal, invoice.getAdjustmentsTotal());
+  }
+
+  public Future<Void> updateVoucherNumberInInvoice(Voucher voucher, RequestContext requestContext) {
+    return getInvoiceById(voucher.getInvoiceId(), requestContext)
+      .compose(invoice -> {
+        invoice.setVoucherNumber(voucher.getVoucherNumber());
+        return updateInvoice(invoice, requestContext);
+      });
   }
 }

--- a/src/main/java/org/folio/services/invoice/BaseInvoiceService.java
+++ b/src/main/java/org/folio/services/invoice/BaseInvoiceService.java
@@ -201,7 +201,7 @@ public class BaseInvoiceService implements InvoiceService {
       .compose(invoice -> {
         invoice.setVoucherNumber(voucher.getVoucherNumber());
         return updateInvoice(invoice, requestContext)
-          .onSuccess(result -> logger.debug("updateVoucherNumberInInvoice:: VoucherNumber '{}' was set to invoice '{}', voucher.getVoucherNumber, invoice.getId"))
+          .onSuccess(result -> logger.debug("updateVoucherNumberInInvoice:: VoucherNumber '{}' was set to invoice '{}'", voucher.getVoucherNumber(), invoice.getId()))
           .onFailure(error -> logger.error("An error occurred", error));
       });
   }


### PR DESCRIPTION
Overview: Performing a search based on voucher number for MG668 (the new voucher number I assigned) produces no results. However, a search for MG68 (the original value) returns the correct record:https://bugfest-mg.int.aws.folio.org/invoice/view/c463c38f-30eb-4a7a-81ec-bda899993a6d?limit=50&offset=0&qindex=voucherNumber&query=MG68
**

Steps to Reproduce:

Log into some FOLIO environment as User X

Create invoice

Approve invoice

Edit voucher number (Add a 1 at beginning of number)

search invoice by voucher number using new number

Expected Results: Invoice is displayed in search result list

Actual Results: No results found for search

Additional Information:
URL: 
Interested parties: