### PR TITLE
MODINVOSTO-172. Add missed module permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -306,7 +306,9 @@
           "modulePermissions": [
             "voucher-storage.vouchers.item.get",
             "voucher-storage.vouchers.item.put",
-            "finance.exchange-rate.item.get"
+            "finance.exchange-rate.item.get",
+            "invoice-storage.invoices.item.get",
+            "invoice-storage.invoices.item.put"
           ]
         },
         {


### PR DESCRIPTION
## Purpose
When updating voucher we also updating voucher number in the corresponding invoice. To do this update we firstly getting invoice by id and updating that invoice with new voucher number.
So 2 module permissions are added, related issue - https://folio-org.atlassian.net/browse/MODINVOICE-542