### PR TITLE
MODINVOICE-545: Unpin jackson fixing Number Parse DoS (PRISMA-2023-0067)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
     <mod-configuration-client.version>5.10.0</mod-configuration-client.version>
     <spring.version>6.1.5</spring.version>
     <folio-di-support.version>2.1.0</folio-di-support.version>
-    <jackson-bom.version>2.13.4</jackson-bom.version>
     <assertj-core.version>3.25.3</assertj-core.version>
     <aspectj.version>1.9.21.1</aspectj.version>
     <log4j.version>2.23.0</log4j.version>
@@ -765,13 +764,6 @@
   </build>
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>${jackson-bom.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODINVOICE-545

jackson-core package versions before 2.15.0 are vulnerable to Denial of Service (DoS): https://github.com/FasterXML/jackson-core/pull/827

mod-invoice pins the jackson version to 2.13.4. This effectively downgrades the jackson version provided by RMB (domain-models-runtime, domain-models-api-interfaces) from 2.16.1 to 2.13.4.

Fix: Unpin jackson.

## Purpose
Fix vulnerability in jackson-core.

## Approach
Unpin jackson.

## Learning
Don't pin dependency versions provided by RMB or Spring.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate action.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code are 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.