### PR TITLE
[MODINVOICE-544]. Add ignore order line payment status, add tests

### DIFF
--- a/src/main/java/org/folio/services/invoice/InvoicePaymentService.java
+++ b/src/main/java/org/folio/services/invoice/InvoicePaymentService.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -43,6 +44,8 @@ public class InvoicePaymentService {
   private CurrentFiscalYearService currentFiscalYearService;
 
   public static final String INVOICE_LINE_MUST_HAVE_FUND = "The invoice line must contain the fund for payment";
+  public static final Set<CompositePoLine.PaymentStatus> ORDER_LINE_PAYMENT_IGNORED_STATUSES =
+      Set.of(CompositePoLine.PaymentStatus.ONGOING, CompositePoLine.PaymentStatus.PAYMENT_NOT_REQUIRED);
 
   /**
    * Handles transition of given invoice to PAID status.
@@ -154,6 +157,6 @@ public class InvoicePaymentService {
   boolean isPaymentStatusUpdateRequired(Map<CompositePoLine, CompositePoLine.PaymentStatus> compositePoLinesWithStatus, CompositePoLine compositePoLine) {
     CompositePoLine.PaymentStatus newPaymentStatus = compositePoLinesWithStatus.get(compositePoLine);
     return (!newPaymentStatus.equals(compositePoLine.getPaymentStatus()) &&
-      !compositePoLine.getPaymentStatus().equals(CompositePoLine.PaymentStatus.ONGOING));
+        !ORDER_LINE_PAYMENT_IGNORED_STATUSES.contains(compositePoLine.getPaymentStatus()));
   }
 }

--- a/src/main/java/org/folio/services/invoice/InvoicePaymentService.java
+++ b/src/main/java/org/folio/services/invoice/InvoicePaymentService.java
@@ -2,6 +2,8 @@ package org.folio.services.invoice;
 
 import static java.util.stream.Collectors.toList;
 import static org.folio.invoices.utils.HelperUtils.collectResultsOnSuccess;
+import static org.folio.rest.acq.model.orders.CompositePoLine.PaymentStatus.ONGOING;
+import static org.folio.rest.acq.model.orders.CompositePoLine.PaymentStatus.PAYMENT_NOT_REQUIRED;
 
 import java.util.Collections;
 import java.util.List;
@@ -44,8 +46,8 @@ public class InvoicePaymentService {
   private CurrentFiscalYearService currentFiscalYearService;
 
   public static final String INVOICE_LINE_MUST_HAVE_FUND = "The invoice line must contain the fund for payment";
-  public static final Set<CompositePoLine.PaymentStatus> ORDER_LINE_PAYMENT_IGNORED_STATUSES =
-      Set.of(CompositePoLine.PaymentStatus.ONGOING, CompositePoLine.PaymentStatus.PAYMENT_NOT_REQUIRED);
+  public static final Set<CompositePoLine.PaymentStatus> PO_LINE_PAYMENT_IGNORED_STATUSES =
+    Set.of(ONGOING, PAYMENT_NOT_REQUIRED);
 
   /**
    * Handles transition of given invoice to PAID status.
@@ -157,6 +159,6 @@ public class InvoicePaymentService {
   boolean isPaymentStatusUpdateRequired(Map<CompositePoLine, CompositePoLine.PaymentStatus> compositePoLinesWithStatus, CompositePoLine compositePoLine) {
     CompositePoLine.PaymentStatus newPaymentStatus = compositePoLinesWithStatus.get(compositePoLine);
     return (!newPaymentStatus.equals(compositePoLine.getPaymentStatus()) &&
-        !ORDER_LINE_PAYMENT_IGNORED_STATUSES.contains(compositePoLine.getPaymentStatus()));
+      !PO_LINE_PAYMENT_IGNORED_STATUSES.contains(compositePoLine.getPaymentStatus()));
   }
 }

--- a/src/test/java/org/folio/services/invoice/InvoicePaymentServiceTest.java
+++ b/src/test/java/org/folio/services/invoice/InvoicePaymentServiceTest.java
@@ -20,9 +20,9 @@ class InvoicePaymentServiceTest {
     Map<CompositePoLine, CompositePoLine.PaymentStatus> compositePoLinesWithStatus = Map.ofEntries(
         Map.entry(poLine, CompositePoLine.PaymentStatus.FULLY_PAID));
     InvoicePaymentService invoicePaymentService = new InvoicePaymentService();
-    boolean actual = invoicePaymentService.isPaymentStatusUpdateRequired(compositePoLinesWithStatus, poLine);
+    boolean paymentRequired = invoicePaymentService.isPaymentStatusUpdateRequired(compositePoLinesWithStatus, poLine);
 
-    Assertions.assertTrue(actual);
+    Assertions.assertTrue(paymentRequired);
   }
 
   @Test
@@ -33,8 +33,8 @@ class InvoicePaymentServiceTest {
     Map<CompositePoLine, CompositePoLine.PaymentStatus> compositePoLinesWithStatus = Map.ofEntries(
         Map.entry(poLine, CompositePoLine.PaymentStatus.FULLY_PAID));
     InvoicePaymentService invoicePaymentService = new InvoicePaymentService();
-    boolean actual = invoicePaymentService.isPaymentStatusUpdateRequired(compositePoLinesWithStatus, poLine);
+    boolean paymentRequired = invoicePaymentService.isPaymentStatusUpdateRequired(compositePoLinesWithStatus, poLine);
 
-    Assertions.assertFalse(actual);
+    Assertions.assertFalse(paymentRequired);
   }
 }

--- a/src/test/java/org/folio/services/invoice/InvoicePaymentServiceTest.java
+++ b/src/test/java/org/folio/services/invoice/InvoicePaymentServiceTest.java
@@ -1,0 +1,40 @@
+package org.folio.services.invoice;
+
+import io.vertx.core.json.JsonObject;
+import org.folio.rest.acq.model.orders.CompositePoLine;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.folio.rest.impl.ApiTestBase.getMockData;
+
+class InvoicePaymentServiceTest {
+
+  @Test
+  void testOrderLinePaymentStatusAwaitingPayment() throws IOException {
+    CompositePoLine poLine = new JsonObject(
+        getMockData("mockdata/compositeOrders/e9496a5c-84d1-4f95-89ad-a764be51ca29.json"))
+        .mapTo(CompositePoLine.class);
+    Map<CompositePoLine, CompositePoLine.PaymentStatus> compositePoLinesWithStatus = Map.ofEntries(
+        Map.entry(poLine, CompositePoLine.PaymentStatus.FULLY_PAID));
+    InvoicePaymentService invoicePaymentService = new InvoicePaymentService();
+    boolean actual = invoicePaymentService.isPaymentStatusUpdateRequired(compositePoLinesWithStatus, poLine);
+
+    Assertions.assertTrue(actual);
+  }
+
+  @Test
+  void testOrderLinePaymentStatusPaymentNotRequiredIgnored() throws IOException {
+    CompositePoLine poLine = new JsonObject(
+        getMockData("mockdata/compositeOrders/443bcf4c-41e9-4a07-8e70-dcc71ca56069.json"))
+        .mapTo(CompositePoLine.class);
+    Map<CompositePoLine, CompositePoLine.PaymentStatus> compositePoLinesWithStatus = Map.ofEntries(
+        Map.entry(poLine, CompositePoLine.PaymentStatus.FULLY_PAID));
+    InvoicePaymentService invoicePaymentService = new InvoicePaymentService();
+    boolean actual = invoicePaymentService.isPaymentStatusUpdateRequired(compositePoLinesWithStatus, poLine);
+
+    Assertions.assertFalse(actual);
+  }
+}

--- a/src/test/java/org/folio/services/invoice/InvoicePaymentServiceTest.java
+++ b/src/test/java/org/folio/services/invoice/InvoicePaymentServiceTest.java
@@ -15,10 +15,10 @@ class InvoicePaymentServiceTest {
   @Test
   void testOrderLinePaymentStatusAwaitingPayment() throws IOException {
     CompositePoLine poLine = new JsonObject(
-        getMockData("mockdata/compositeOrders/e9496a5c-84d1-4f95-89ad-a764be51ca29.json"))
-        .mapTo(CompositePoLine.class);
+      getMockData("mockdata/compositeOrders/e9496a5c-84d1-4f95-89ad-a764be51ca29.json"))
+      .mapTo(CompositePoLine.class);
     Map<CompositePoLine, CompositePoLine.PaymentStatus> compositePoLinesWithStatus = Map.ofEntries(
-        Map.entry(poLine, CompositePoLine.PaymentStatus.FULLY_PAID));
+      Map.entry(poLine, CompositePoLine.PaymentStatus.FULLY_PAID));
     InvoicePaymentService invoicePaymentService = new InvoicePaymentService();
     boolean paymentRequired = invoicePaymentService.isPaymentStatusUpdateRequired(compositePoLinesWithStatus, poLine);
 
@@ -28,10 +28,10 @@ class InvoicePaymentServiceTest {
   @Test
   void testOrderLinePaymentStatusPaymentNotRequiredIgnored() throws IOException {
     CompositePoLine poLine = new JsonObject(
-        getMockData("mockdata/compositeOrders/443bcf4c-41e9-4a07-8e70-dcc71ca56069.json"))
-        .mapTo(CompositePoLine.class);
+      getMockData("mockdata/compositeOrders/443bcf4c-41e9-4a07-8e70-dcc71ca56069.json"))
+      .mapTo(CompositePoLine.class);
     Map<CompositePoLine, CompositePoLine.PaymentStatus> compositePoLinesWithStatus = Map.ofEntries(
-        Map.entry(poLine, CompositePoLine.PaymentStatus.FULLY_PAID));
+      Map.entry(poLine, CompositePoLine.PaymentStatus.FULLY_PAID));
     InvoicePaymentService invoicePaymentService = new InvoicePaymentService();
     boolean paymentRequired = invoicePaymentService.isPaymentStatusUpdateRequired(compositePoLinesWithStatus, poLine);
 

--- a/src/test/resources/mockdata/compositeOrders/443bcf4c-41e9-4a07-8e70-dcc71ca56069.json
+++ b/src/test/resources/mockdata/compositeOrders/443bcf4c-41e9-4a07-8e70-dcc71ca56069.json
@@ -1,0 +1,66 @@
+{
+  "id": "443bcf4c-41e9-4a07-8e70-dcc71ca56069",
+  "cost": {
+    "currency": "USD",
+    "discountType": "percentage",
+    "listUnitPrice": 1.0,
+    "quantityPhysical": 1,
+    "poLineEstimatedPrice": 1.0
+  },
+  "rush": false,
+  "alerts": [],
+  "claims": [],
+  "source": "User",
+  "details": {
+    "productIds": [],
+    "isAcknowledged": false,
+    "isBinderyActive": false,
+    "subscriptionInterval": 0
+  },
+  "metadata": {
+    "createdDate": "2024-05-30T08:06:56.589Z",
+    "updatedDate": "2024-05-30T08:07:35.529Z",
+    "createdByUserId": "b24259db-dcef-4143-b471-1f7c1cfbda98",
+    "updatedByUserId": "b24259db-dcef-4143-b471-1f7c1cfbda98"
+  },
+  "physical": {
+    "volumes": [],
+    "materialType": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+    "createInventory": "Instance, Holding, Item",
+    "materialSupplier": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1"
+  },
+  "isPackage": false,
+  "locations": [
+    {
+      "quantity": 1,
+      "holdingId": "abacfc6e-42e5-41c5-84d4-9f5733534804",
+      "quantityPhysical": 1
+    }
+  ],
+  "collection": false,
+  "instanceId": "7674a434-4609-4086-b3c7-ed6f40d48b71",
+  "orderFormat": "Physical Resource",
+  "checkinItems": true,
+  "contributors": [],
+  "poLineNumber": "10016-1",
+  "vendorDetail": {
+    "instructions": "",
+    "vendorAccount": "1234",
+    "referenceNumbers": []
+  },
+  "paymentStatus": "Payment Not Required",
+  "receiptStatus": "Awaiting Receipt",
+  "claimingActive": false,
+  "reportingCodes": [],
+  "titleOrPackage": "Test 7",
+  "automaticExport": false,
+  "purchaseOrderId": "65842f8e-b90d-44bb-a233-d750e5757510",
+  "claimingInterval": 45,
+  "fundDistribution": [],
+  "acquisitionMethod": "306489dd-0053-49ee-a068-c316444a8f55",
+  "searchLocationIds": [
+    "fcd64ce1-6995-48f0-840e-89ffa2288371"
+  ],
+  "donorOrganizationIds": [],
+  "cancellationRestriction": true
+}

--- a/src/test/resources/mockdata/compositeOrders/e9496a5c-84d1-4f95-89ad-a764be51ca29.json
+++ b/src/test/resources/mockdata/compositeOrders/e9496a5c-84d1-4f95-89ad-a764be51ca29.json
@@ -1,0 +1,75 @@
+{
+  "id": "e9496a5c-84d1-4f95-89ad-a764be51ca29",
+  "cost": {
+    "currency": "USD",
+    "discountType": "percentage",
+    "listUnitPrice": 1.0,
+    "quantityPhysical": 1,
+    "poLineEstimatedPrice": 1.0
+  },
+  "rush": false,
+  "alerts": [],
+  "claims": [],
+  "source": "User",
+  "details": {
+    "productIds": [],
+    "isAcknowledged": false,
+    "isBinderyActive": false,
+    "subscriptionInterval": 0
+  },
+  "metadata": {
+    "createdDate": "2024-05-30T08:14:09.414Z",
+    "updatedDate": "2024-05-30T08:16:28.131Z",
+    "createdByUserId": "b24259db-dcef-4143-b471-1f7c1cfbda98",
+    "updatedByUserId": "b24259db-dcef-4143-b471-1f7c1cfbda98"
+  },
+  "physical": {
+    "volumes": [],
+    "materialType": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+    "createInventory": "Instance, Holding, Item",
+    "materialSupplier": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1"
+  },
+  "isPackage": false,
+  "locations": [
+    {
+      "quantity": 1,
+      "holdingId": "7d5fe25c-2df9-4c35-a09a-0b168511fbe3",
+      "quantityPhysical": 1
+    }
+  ],
+  "collection": false,
+  "instanceId": "008dee13-1a08-4a69-b2b8-49986654047a",
+  "orderFormat": "Physical Resource",
+  "checkinItems": false,
+  "contributors": [],
+  "poLineNumber": "10018-1",
+  "vendorDetail": {
+    "instructions": "",
+    "vendorAccount": "1234",
+    "referenceNumbers": []
+  },
+  "paymentStatus": "Awaiting Payment",
+  "receiptStatus": "Awaiting Receipt",
+  "claimingActive": false,
+  "reportingCodes": [],
+  "titleOrPackage": "Test 8",
+  "automaticExport": false,
+  "purchaseOrderId": "9fe04405-fc1b-4dbc-b1ed-4fa26fb0d667",
+  "claimingInterval": 45,
+  "fundDistribution": [
+    {
+      "code": "AFRICAHIST",
+      "value": 100.0,
+      "fundId": "7fbd5d84-62d1-44c6-9c45-6cb173998bbd",
+      "encumbrance": "592bc75e-1d32-431e-a5cd-db10138952fa",
+      "expenseClassId": "1bcc3247-99bf-4dca-9b0f-7bc51a2998c2",
+      "distributionType": "percentage"
+    }
+  ],
+  "acquisitionMethod": "306489dd-0053-49ee-a068-c316444a8f55",
+  "searchLocationIds": [
+    "fcd64ce1-6995-48f0-840e-89ffa2288371"
+  ],
+  "donorOrganizationIds": [],
+  "cancellationRestriction": true
+}


### PR DESCRIPTION
## Purpose

[[MODINVOICE-544] POL payment status "Payment not required" is changed to "Fully paid" after invoice was paid](<https://folio-org.atlassian.net/browse/MODINVOICE-544?atlOrigin=eyJpIjoiYzZkYmFmMDFlYjVjNGFlYWFlNjRhNzY2OTE1MTFiZmIiLCJwIjoiaiJ9>)

## Approach

- Add ignore **Payment Not Required** during payment status update
- Applied for both invoice payment and invoice cancellation