### PR TITLE
[MODINVOICE-547] - Separate credits from expenditures in mod-invoice

### DIFF
--- a/src/main/java/org/folio/services/validator/FundAvailabilityHolderValidator.java
+++ b/src/main/java/org/folio/services/validator/FundAvailabilityHolderValidator.java
@@ -79,11 +79,12 @@ public class FundAvailabilityHolderValidator implements HolderValidator {
 
   private boolean isRemainingAmountExceed(Budget budget, MonetaryAmount totalExpendedAmount) {
     // [remaining amount we can expend] = (totalFunding * allowableExpenditure) - expended
-    // where expended = awaitingPayment + expenditure
+    // where expended = awaitingPayment + expenditure - credited
     CurrencyUnit currency = totalExpendedAmount.getCurrency();
     Money totalFundings = Money.of(budget.getTotalFunding(), currency);
     Money expended = Money.of(budget.getAwaitingPayment(), currency)
-      .add(Money.of(budget.getExpenditures(), currency));
+      .add(Money.of(budget.getExpenditures(), currency))
+      .subtract(Money.of(budget.getCredits(), currency));
     BigDecimal allowableExpenditures = BigDecimal.valueOf(budget.getAllowableExpenditure())
       .movePointLeft(2);
     Money totalAmountCanBeExpended = totalFundings.multiply(allowableExpenditures);

--- a/src/main/java/org/folio/services/validator/FundAvailabilityHolderValidator.java
+++ b/src/main/java/org/folio/services/validator/FundAvailabilityHolderValidator.java
@@ -76,9 +76,12 @@ public class FundAvailabilityHolderValidator implements HolderValidator {
       .orElseGet(() -> Money.zero(currency));
   }
 
+  /**
+   * Method is following these formulas <br>
+   * afterApproveExpended [remaining amount we can expend] = expended - credited + (totalFunding * allowableExpenditure) <br>
+   * expended = awaitingPayment + expenditure
+   */
   private boolean isRemainingAmountExceed(Budget budget, MonetaryAmount totalExpendedAmount) {
-    // [remaining amount we can expend] = (totalFunding * allowableExpenditure) - expended
-    // where expended = awaitingPayment + expenditure - credited
     CurrencyUnit currency = totalExpendedAmount.getCurrency();
     Money totalFundings = Money.of(budget.getTotalFunding(), currency);
     Money expended = Money.of(budget.getAwaitingPayment(), currency)

--- a/src/main/java/org/folio/services/validator/FundAvailabilityHolderValidator.java
+++ b/src/main/java/org/folio/services/validator/FundAvailabilityHolderValidator.java
@@ -78,19 +78,23 @@ public class FundAvailabilityHolderValidator implements HolderValidator {
 
   /**
    * Method is following these formulas <br>
-   * afterApproveExpended [remaining amount we can expend] = expended - credited + (totalFunding * allowableExpenditure) <br>
-   * expended = awaitingPayment + expenditure
+   * afterApproveExpended [remaining amount we can expend] = expended - credited + awaitingPayment + additionalAmountToExpend <br>
+   * totalAmountCanBeExpended = totalFunding * allowableExpenditure
+   * @param additionalAmountToExpend additionalAmountToExpend
+   * @return boolean afterApproveExpended > totalAmountCanBeExpended
    */
-  private boolean isRemainingAmountExceed(Budget budget, MonetaryAmount totalExpendedAmount) {
-    CurrencyUnit currency = totalExpendedAmount.getCurrency();
-    Money totalFundings = Money.of(budget.getTotalFunding(), currency);
-    Money expended = Money.of(budget.getAwaitingPayment(), currency)
-      .add(Money.of(budget.getExpenditures(), currency));
+  private boolean isRemainingAmountExceed(Budget budget, MonetaryAmount additionalAmountToExpend) {
+    CurrencyUnit currency = additionalAmountToExpend.getCurrency();
+
+    Money totalFunding = Money.of(budget.getTotalFunding(), currency);
+    Money awaitingPayment = Money.of(budget.getAwaitingPayment(), currency);
+    Money expended = Money.of(budget.getExpenditures(), currency);
     Money credited = Money.of(budget.getCredits(), currency);
-    BigDecimal allowableExpenditures = BigDecimal.valueOf(budget.getAllowableExpenditure())
-      .movePointLeft(2);
-    Money totalAmountCanBeExpended = totalFundings.multiply(allowableExpenditures);
-    Money afterApproveExpended = expended.subtract(credited).add(totalExpendedAmount);
+    BigDecimal allowableExpenditures = BigDecimal.valueOf(budget.getAllowableExpenditure()).movePointLeft(2);
+
+    Money totalAmountCanBeExpended = totalFunding.multiply(allowableExpenditures);
+    Money afterApproveExpended = expended.subtract(credited).add(awaitingPayment).add(additionalAmountToExpend);
+
     return afterApproveExpended.isGreaterThan(totalAmountCanBeExpended);
   }
 


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODINVOICE-547
## Approach
Changed calculation 
replace: [remaining amount] = (allocated + netTransfers) * allowableExpenditure - (awaitingPayment + expended)
by: [remaining amount] = (allocated + netTransfers) * allowableExpenditure - (awaitingPayment + expended - credited)