### PR TITLE
Add missed fiscal year permission for POST invoice

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -30,7 +30,8 @@
             "invoice-storage.invoice-number.get",
             "acquisitions-units-storage.units.collection.get",
             "acquisitions-units-storage.memberships.collection.get",
-            "organizations-storage.organizations.item.get"
+            "organizations-storage.organizations.item.get",
+            "finance.ledgers.current-fiscal-year.item.get"
           ]
         },
         {


### PR DESCRIPTION
## Purpose
Method GetCurrentFiscalYear is used in validation for both POST and PUT invoice. Module permission declaration for POST invoice was missed.