### PR TITLE
MODINVOICE-552: Vert.x 4.5.9, Netty 4.1.111, Apache sshd/sftp 2.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,10 @@
     <!--Dependencies-->
     <raml-module-builder.version>35.2.0</raml-module-builder.version>
     <jaxb-api.version>2.3.3</jaxb-api.version>
-    <vertx.version>4.5.4</vertx.version>
+    <vertx.version>4.5.9</vertx.version>
     <rest-assured.version>5.4.0</rest-assured.version>
     <mod-configuration-client.version>5.10.0</mod-configuration-client.version>
+    <sshd.version>2.13.2</sshd.version>
     <spring.version>6.1.12</spring.version>
     <folio-di-support.version>2.1.0</folio-di-support.version>
     <assertj-core.version>3.25.3</assertj-core.version>
@@ -89,17 +90,14 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
-      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>${vertx.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -110,24 +108,22 @@
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-sftp</artifactId>
-      <version>2.9.3</version>
+      <version>${sshd.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-spring-sftp</artifactId>
-      <version>2.8.0</version>
+      <version>${sshd.version}</version>
     </dependency>
     <!--vertx-rx-java required for vertx-concurrent-1.0.0 -->
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-rx-java</artifactId>
-      <version>${vertx.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-junit5</artifactId>
-      <version>${vertx.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -230,25 +226,21 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>1.19.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -780,6 +772,20 @@
         <groupId>org.springframework</groupId>
         <artifactId>spring-framework-bom</artifactId>
         <version>${spring.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+       </dependency>
+       <dependency>
+         <groupId>io.vertx</groupId>
+         <artifactId>vertx-stack-depchain</artifactId>
+         <version>${vertx.version}</version>
+         <scope>import</scope>
+         <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>${testcontainers.version}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODINVOICE-552

Upgrade Vert.x from 4.5.4 to 4.5.9.

This indirectly upgrades Netty from 4.1.107.Final to 4.1.111.Final fixing Allocation of Resources Without Limits or Throttling:
* https://security.snyk.io/package/maven/io.netty:netty-codec-http/4.1.107.Final

Upgrade Apache SSHD/SFTP from 2.8.0/2.9.0 to 2.13.2 fixing vulnerabilities:

* https://security.snyk.io/package/maven/org.apache.sshd:sshd-common/2.9.0
* https://security.snyk.io/package/maven/org.apache.sshd:sshd-core/2.9.0
* https://security.snyk.io/package/maven/org.apache.sshd:sshd-sftp/2.9.0

To avoid diverging versions use dependencyManagement for vertx and testcontainers.

## Purpose
Fix vulnerabilities.

## Approach
Upgrade Vert.x and sshd/sftp dependencies.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate action.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code are 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.