### PR TITLE
Update data-import-processing-core to released version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <!--Folio dependencies properties-->
     <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
-    <mod-configuration-client.version>5.10.0</mod-configuration-client.version>
+    <mod-configuration-client.version>5.11.0</mod-configuration-client.version>
 
     <!--Maven plugin dependencies-->
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
@@ -179,7 +179,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>4.3.0-SNAPSHOT</version>
+      <version>4.3.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.folio</groupId>


### PR DESCRIPTION
## Purpose
data-import-processing-core was released and snapshot version does not exist any more. Need to switch to released version to avoid failing builds.