### PR TITLE
MODINVOICE-566. Error When Run Batch Voucher Export Manually

### DIFF
--- a/src/main/java/org/folio/services/voucher/BatchVoucherGenerateService.java
+++ b/src/main/java/org/folio/services/voucher/BatchVoucherGenerateService.java
@@ -16,6 +16,7 @@ import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.converters.AddressConverter;
+import org.folio.dbschema.ObjectMapperTool;
 import org.folio.invoices.rest.exceptions.HttpException;
 import org.folio.rest.acq.model.Address;
 import org.folio.rest.acq.model.FundDistribution;
@@ -212,7 +213,7 @@ public class BatchVoucherGenerateService {
   }
 
   private String buildBatchVoucherQuery(BatchVoucherExport batchVoucherExport) {
-    JsonObject voucherJSON = JsonObject.mapFrom(batchVoucherExport);
+    JsonObject voucherJSON = new JsonObject(ObjectMapperTool.valueAsString(batchVoucherExport));
     String voucherStart = voucherJSON.getString("start");
     String voucherEnd = voucherJSON.getString("end");
     return "batchGroupId==" + batchVoucherExport.getBatchGroupId() + " and voucherDate>=" + voucherStart


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODINVOICE-566

## Approach
After upgrading to new version RMB this issue become occurring:
![vouchers](https://github.com/user-attachments/assets/9f9e37ec-e9bc-4e97-bfeb-55fafd70d520)

It is because there is note in https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md#version-353
`Don't use JsonObject.mapFrom to serialize a Java class instance to JSON, RMB's database methods take a Java class and automatically serialize it. When writing custom SQL use ObjectMapperTool.valueAsString to serialize in a way compatible with RMB's deserializer.`

After the fix:
![after_fix](https://github.com/user-attachments/assets/2d662c2e-19f3-4dcc-bc3a-8aca325a199d)
