### PR TITLE
MODINVOICE-568 Use system user during data-import invoice creation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 6.0.0 - Unreleased
-
+* [MODINVOICE-568](https://folio-org.atlassian.net/browse/MODINVOICE-568) - Use system user token in DI kafka handlers
+* 
 ## 5.9.0 - Released (Ramsons R2 2024)
 The focus of this release was to update libraries, separate credits from expenditures, and fix various bugs.
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1113,10 +1113,13 @@
         "invoice-storage.invoices.item.get",
         "invoice-storage.invoices.item.put",
         "acquisitions-units-storage.units.collection.get",
-        "acquisitions-units.memberships.collection.get",
-        "acquisitions-units.units.collection.get",
+        "acquisitions-units-storage.units.collection.get",
+        "acquisitions-units-storage.memberships.collection.get",
         "orders.po-lines.collection.get",
-        "orders.po-lines.item.get"
+        "orders.po-lines.item.get",
+        "orders-storage.order-invoice-relationships.collection.get",
+        "orders-storage.order-invoice-relationships.item.post",
+        "acquisitions-units-storage.memberships.collection.get"
       ]
     }
   },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1097,6 +1097,29 @@
       "description": "Ability to manage acquisition unit and update invoice"
     }
   ],
+  "metadata": {
+    "user": {
+      "type": "system",
+      "permissions": [
+        "finance-storage.fiscal-years.item.get",
+        "converter-storage.jobprofilesnapshots.get",
+        "organizations-storage.organizations.item.get",
+        "invoice-storage.invoice-lines.collection.get",
+        "invoice-storage.invoice-lines.item.post",
+        "invoice-storage.invoice-line-number.get",
+        "invoice-storage.invoice-lines.item.put",
+        "invoice-storage.invoice-number.get",
+        "invoice-storage.invoices.item.post",
+        "invoice-storage.invoices.item.get",
+        "invoice-storage.invoices.item.put",
+        "acquisitions-units-storage.units.collection.get",
+        "acquisitions-units.memberships.collection.get",
+        "acquisitions-units.units.collection.get",
+        "orders.po-lines.collection.get",
+        "orders.po-lines.item.get"
+      ]
+    }
+  },
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",
     "dockerPull": false,

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>4.3.0</version>
+      <version>4.4.0-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <groupId>org.folio</groupId>

--- a/src/main/java/org/folio/dataimport/utils/DataImportUtils.java
+++ b/src/main/java/org/folio/dataimport/utils/DataImportUtils.java
@@ -3,6 +3,7 @@ package org.folio.dataimport.utils;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.folio.DataImportEventPayload;
@@ -13,23 +14,49 @@ import org.folio.utils.UserPermissionsUtil;
 public class DataImportUtils {
   public static final String DATA_IMPORT_PAYLOAD_OKAPI_PERMISSIONS = "data-import-payload-okapi-permissions";
   public static final String DATA_IMPORT_PAYLOAD_OKAPI_USER_ID = "data-import-payload-okapi-user-id";
+  private static final String USER_ID = "userId";
 
   private DataImportUtils() {}
 
   public static Map<String, String> getOkapiHeaders(DataImportEventPayload eventPayload) {
     Map<String, String> result = new HashMap<>();
     result.put(RestVerticle.OKAPI_HEADER_TENANT, eventPayload.getTenant());
-    result.put(RestVerticle.OKAPI_HEADER_TOKEN, eventPayload.getToken());
     result.put(RestConstants.OKAPI_URL, eventPayload.getOkapiUrl());
 
-    String payloadPermissions = eventPayload.getContext().get(DATA_IMPORT_PAYLOAD_OKAPI_PERMISSIONS);
-    if (StringUtils.isNotBlank(payloadPermissions)) {
-      result.put(UserPermissionsUtil.OKAPI_HEADER_PERMISSIONS, payloadPermissions);
+    if (!isSystemUserEnabled()) {
+      result.put(RestVerticle.OKAPI_HEADER_TOKEN, eventPayload.getToken());
     }
-    String userId = eventPayload.getContext().get(DATA_IMPORT_PAYLOAD_OKAPI_USER_ID);
-    if (StringUtils.isNotBlank(userId)) {
-      result.put(RestVerticle.OKAPI_USERID_HEADER, userId);
-    }
+
+    Optional.ofNullable(eventPayload.getContext().get(DATA_IMPORT_PAYLOAD_OKAPI_PERMISSIONS))
+      .filter(StringUtils::isNotBlank)
+      .ifPresent(permissions -> result.put(UserPermissionsUtil.OKAPI_HEADER_PERMISSIONS, permissions));
+
+    getUserId(eventPayload)
+      .ifPresent(userId -> result.put(RestVerticle.OKAPI_USERID_HEADER, userId));
+
     return Collections.unmodifiableMap(result);
   }
+
+  private static Optional<String> getUserId(DataImportEventPayload eventPayload) {
+    return Optional.ofNullable(eventPayload.getContext().get(DATA_IMPORT_PAYLOAD_OKAPI_USER_ID))
+      .filter(StringUtils::isNotBlank)
+      .or(() -> Optional.ofNullable(eventPayload.getContext().get(USER_ID))
+        .filter(StringUtils::isNotBlank));
+  }
+
+  /**
+   * Checks if the system user is enabled based on a system property.
+   * <p>
+   * This method reads the `SYSTEM_USER_ENABLED` system property and parses
+   * its value as a boolean. If the property is not found or cannot be parsed,
+   * it defaults to `true`. The method then negates the parsed value and returns it.
+   * <p>
+   * Note: This functionality is specific to the Eureka environment.
+   *
+   * @return {@code true} if the system user is set for Eureka env; otherwise {@code false}.
+   */
+  private static boolean isSystemUserEnabled() {
+    return !Boolean.parseBoolean(System.getProperty("SYSTEM_USER_ENABLED", "true"));
+  }
+
 }


### PR DESCRIPTION
* [MODINVOICE-568](https://issues.folio.org/browse/MODINVOICE-568) Use system user for handling DI events

To support DI operation in Eureka, we should implement support for performing asynchronous operations on behalf of a system user. 

## Approach
Add system user to handle data-import events with null or empty token