### PR TITLE
Rollback pending payment creation if an error occurs during approval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /bin/
 /.project
 /.classpath
+/src/main/resources/postgres-conf.json

--- a/src/main/java/org/folio/InvoiceWorkflowDataHolderBuilder.java
+++ b/src/main/java/org/folio/InvoiceWorkflowDataHolderBuilder.java
@@ -166,7 +166,7 @@ public class InvoiceWorkflowDataHolderBuilder {
 
   public Future<List<InvoiceWorkflowDataHolder>> withEncumbrances(List<InvoiceWorkflowDataHolder> holders, RequestContext requestContext) {
     List<String> trIds = holders.stream().map(InvoiceWorkflowDataHolder::getFundDistribution).map(FundDistribution::getEncumbrance).distinct().filter(Objects::nonNull).collect(toList());
-    return baseTransactionService.getTransactions(trIds, requestContext)
+    return baseTransactionService.getTransactionsByIds(trIds, requestContext)
       .map(transactions -> transactions.stream().collect(toMap(Transaction::getId, Function.identity())))
       .map(idTransactionMap -> holders.stream()
         .map(holder -> holder.withEncumbrance(idTransactionMap.get(holder.getFundDistribution().getEncumbrance())))

--- a/src/main/java/org/folio/services/finance/transaction/BaseTransactionService.java
+++ b/src/main/java/org/folio/services/finance/transaction/BaseTransactionService.java
@@ -51,7 +51,7 @@ public class BaseTransactionService {
       .onFailure(t -> logger.error("getTransactions failed, query={}", query, t));
   }
 
-  public Future<List<Transaction>> getTransactions(List<String> transactionIds, RequestContext requestContext) {
+  public Future<List<Transaction>> getTransactionsByIds(List<String> transactionIds, RequestContext requestContext) {
     if (!CollectionUtils.isEmpty(transactionIds)) {
       List<Future<TransactionCollection>> expenseClassesFutureList = StreamEx
         .ofSubLists(transactionIds, MAX_IDS_FOR_GET_RQ)
@@ -117,11 +117,15 @@ public class BaseTransactionService {
     return batchUpdate(transactions, requestContext);
   }
 
-
   public Future<Void> batchCancel(List<Transaction> transactions, RequestContext requestContext) {
     // NOTE: we will have to use transactionPatches when it is available (see MODINVOICE-521)
     transactions.forEach(tr -> tr.setInvoiceCancelled(true));
     return batchUpdate(transactions, requestContext);
+  }
+
+  public Future<Void> batchDelete(List<Transaction> transactions, RequestContext requestContext) {
+    List<String> ids = transactions.stream().map(Transaction::getId).toList();
+    return batchAllOrNothing(null, null, ids, null, requestContext);
   }
 
 }

--- a/src/test/java/org/folio/services/finance/transaction/BaseTransactionServiceTest.java
+++ b/src/test/java/org/folio/services/finance/transaction/BaseTransactionServiceTest.java
@@ -74,7 +74,7 @@ public class BaseTransactionServiceTest extends ApiTestBase {
     //When
 
     List<String> transactionIds = encumbrances.stream().map(Transaction::getId).collect(toList());
-    var future = service.getTransactions(transactionIds, requestContext);
+    var future = service.getTransactionsByIds(transactionIds, requestContext);
     vertxTestContext.assertComplete(future)
       .onComplete(result -> {
         assertThat(result.result(), hasSize(1));
@@ -91,7 +91,7 @@ public class BaseTransactionServiceTest extends ApiTestBase {
     RequestContext requestContext = new RequestContext(ctxMock, okapiHeaders);
      //When
     List<String> transactionIds = new ArrayList<>();
-    var future = service.getTransactions(transactionIds, requestContext);
+    var future = service.getTransactionsByIds(transactionIds, requestContext);
     //Then
     vertxTestContext.assertComplete(future)
       .onComplete(result -> {


### PR DESCRIPTION
## Purpose
[MODINVOICE-519](https://folio-org.atlassian.net/browse/MODINVOICE-519) - Rollback pending payment creation if an error occurs during approval

## Approach
- When approving an invoice, catch errors happening after the pending payments have been created.
- In this case, rollback the creation of the pending payments by deleting them.
- Also rollback the release of encumbrances, by using the old encumbrances stored in the holders and comparing them to newly retrieved encumbrances; the encumbrances that have been released are unreleased.
- Rethrow the initial error
- New unit test checking the rollbacks
- Also added `postgres-conf.json` to `.gitignore`

Note: there is no integration test for this ticket; if there was an error after creating pending payments we would have to fix it and the test wouldn't work anymore.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate action.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code are 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
