### PR TITLE
[MODORDERS-1269] Single po line schema, no sub-object

### DIFF
--- a/src/main/java/org/folio/rest/impl/InvoiceLineHelper.java
+++ b/src/main/java/org/folio/rest/impl/InvoiceLineHelper.java
@@ -36,9 +36,9 @@ import org.folio.invoices.utils.InvoiceRestrictionsUtil;
 import org.folio.invoices.utils.ProtectedOperationType;
 import org.folio.models.InvoiceWorkflowDataHolder;
 import org.folio.okapi.common.GenericCompositeFuture;
-import org.folio.rest.acq.model.orders.CompositePoLine;
 import org.folio.rest.acq.model.orders.CompositePurchaseOrder;
 import org.folio.rest.acq.model.orders.OrderInvoiceRelationship;
+import org.folio.rest.acq.model.orders.PoLine;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.Adjustment;
 import org.folio.rest.jaxrs.model.Invoice;
@@ -608,7 +608,7 @@ public class InvoiceLineHelper extends AbstractHelper {
     if (!invoicePoNumbers.contains(orderPoNumber))
       return succeededFuture(null);
     // check the other invoice lines to see if one of them is linking to the same order
-    List<String> orderLineIds = order.getCompositePoLines().stream().map(CompositePoLine::getId).toList();
+    List<String> orderLineIds = order.getPoLines().stream().map(PoLine::getId).toList();
     return getRelatedLines(invoiceLine, requestContext).compose(lines -> {
       if (lines.stream().noneMatch(line -> orderLineIds.contains(line.getPoLineId()))) {
         List<String> newNumbers = invoicePoNumbers.stream().filter(n -> !n.equals(orderPoNumber)).collect(toList());

--- a/src/main/java/org/folio/services/order/OrderService.java
+++ b/src/main/java/org/folio/services/order/OrderService.java
@@ -9,7 +9,6 @@ import static org.folio.invoices.utils.ResourcePathResolver.resourcesPath;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.vertx.core.Future;
 import org.apache.logging.log4j.LogManager;
@@ -132,7 +131,7 @@ public class OrderService {
     return getOrderInvoiceRelationshipByInvoiceId(invoiceId, requestContext)
       .compose(relation -> {
         if (relation.getTotalRecords() > 0) {
-          List<String> ids = relation.getOrderInvoiceRelationships().stream().map(OrderInvoiceRelationship::getId).collect(Collectors.toList());
+          List<String> ids = relation.getOrderInvoiceRelationships().stream().map(OrderInvoiceRelationship::getId).toList();
           return deleteOrderInvoiceRelations(ids, requestContext);
         }
         return succeededFuture(null);
@@ -144,7 +143,7 @@ public class OrderService {
       .map(PoLine::getPurchaseOrderId)
       .compose(orderId -> getOrderPoLines(orderId, requestContext)
         .map(poLines -> poLines.stream()
-          .map(PoLine::getId).collect(Collectors.toList())))
+          .map(PoLine::getId).toList()))
       .compose(poLineIds -> invoiceLineService.getInvoiceLinesRelatedForOrder(poLineIds, invoiceLine.getInvoiceId(), requestContext))
       .map(invoiceLines -> invoiceLines.size() == 1);
   }

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -128,7 +128,6 @@ import org.folio.rest.acq.model.finance.Ledger;
 import org.folio.rest.acq.model.finance.LedgerCollection;
 import org.folio.rest.acq.model.finance.Transaction;
 import org.folio.rest.acq.model.finance.TransactionCollection;
-import org.folio.rest.acq.model.orders.CompositePoLine;
 import org.folio.rest.acq.model.orders.CompositePurchaseOrder;
 import org.folio.rest.acq.model.orders.OrderInvoiceRelationshipCollection;
 import org.folio.rest.acq.model.orders.PoLine;
@@ -136,8 +135,26 @@ import org.folio.rest.acq.model.orders.PoLineCollection;
 import org.folio.rest.acq.model.units.AcquisitionsUnit;
 import org.folio.rest.acq.model.units.AcquisitionsUnitCollection;
 import org.folio.rest.acq.model.units.AcquisitionsUnitMembershipCollection;
-import org.folio.rest.jaxrs.model.*;
+import org.folio.rest.jaxrs.model.BatchVoucher;
+import org.folio.rest.jaxrs.model.BatchVoucherExport;
+import org.folio.rest.jaxrs.model.BatchVoucherExportCollection;
+import org.folio.rest.jaxrs.model.Config;
+import org.folio.rest.jaxrs.model.Configs;
+import org.folio.rest.jaxrs.model.Credentials;
+import org.folio.rest.jaxrs.model.Document;
+import org.folio.rest.jaxrs.model.DocumentCollection;
 import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.rest.jaxrs.model.ExportConfig;
+import org.folio.rest.jaxrs.model.ExportConfigCollection;
+import org.folio.rest.jaxrs.model.Invoice;
+import org.folio.rest.jaxrs.model.InvoiceCollection;
+import org.folio.rest.jaxrs.model.InvoiceDocument;
+import org.folio.rest.jaxrs.model.InvoiceLine;
+import org.folio.rest.jaxrs.model.InvoiceLineCollection;
+import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+import org.folio.rest.jaxrs.model.Voucher;
+import org.folio.rest.jaxrs.model.VoucherCollection;
 import org.mockftpserver.fake.FakeFtpServer;
 import org.mockftpserver.fake.UserAccount;
 import org.mockftpserver.fake.filesystem.DirectoryEntry;
@@ -1269,7 +1286,7 @@ public class MockServer {
         ctx.response().setStatusCode(404).end(id);
       } else {
         // validate content against schema
-        CompositePoLine poLineSchema = poLine.mapTo(CompositePoLine.class);
+        PoLine poLineSchema = poLine.mapTo(PoLine.class);
         poLineSchema.setId(id);
         poLine = JsonObject.mapFrom(poLineSchema);
 
@@ -1280,7 +1297,7 @@ public class MockServer {
 
   private JsonObject getOrderLineById(String id) {
     if (ID_FOR_INTERNAL_SERVER_ERROR_PUT.equals(id)) {
-      CompositePoLine poLine = new CompositePoLine();
+      PoLine poLine = new PoLine();
       poLine.setId(ID_FOR_INTERNAL_SERVER_ERROR_PUT);
       return JsonObject.mapFrom(poLine);
     }

--- a/src/test/java/org/folio/services/invoice/InvoiceCancelServiceTest.java
+++ b/src/test/java/org/folio/services/invoice/InvoiceCancelServiceTest.java
@@ -53,7 +53,6 @@ import org.folio.rest.acq.model.finance.Encumbrance;
 import org.folio.rest.acq.model.finance.BudgetCollection;
 import org.folio.rest.acq.model.finance.TransactionCollection;
 import org.folio.rest.acq.model.finance.Transaction.TransactionType;
-import org.folio.rest.acq.model.orders.CompositePoLine;
 import org.folio.rest.acq.model.orders.PoLine;
 import org.folio.rest.acq.model.orders.PoLineCollection;
 import org.folio.rest.acq.model.orders.PurchaseOrder;
@@ -264,7 +263,7 @@ public class InvoiceCancelServiceTest {
     Future<Void> future = cancelService.cancelInvoice(invoice, invoiceLines, null, requestContext);
     vertxTestContext.assertComplete(future)
       .onSuccess(result -> {
-        verify(restClient, times(2)).put(any(RequestEntry.class), any(CompositePoLine.class),
+        verify(restClient, times(2)).put(any(RequestEntry.class), any(PoLine.class),
           eq(requestContext));
         vertxTestContext.completeNow();
       })
@@ -441,7 +440,7 @@ public class InvoiceCancelServiceTest {
       .when(restClient).get(any(RequestEntry.class), eq(InvoiceCollection.class), eq(requestContext));
   }
 
-  private void setupUpdatePoLinesQuery(List<CompositePoLine> expectedPoLines) {
+  private void setupUpdatePoLinesQuery(List<PoLine> expectedPoLines) {
     expectedPoLines.forEach(expectedPoLine ->
       doReturn(succeededFuture(null))
         .when(restClient).put(any(RequestEntry.class), eq(expectedPoLine), eq(requestContext))
@@ -490,10 +489,10 @@ public class InvoiceCancelServiceTest {
     setupPoLineQuery(poLines);
     setupInvoiceLineQuery(relatedInvoiceLines);
     setupInvoiceQuery(relatedInvoices);
-    CompositePoLine expectedPoLine1 = JsonObject.mapFrom(poLines.get(0)).mapTo(CompositePoLine.class)
-        .withPaymentStatus(CompositePoLine.PaymentStatus.PARTIALLY_PAID);
-    CompositePoLine expectedPoLine2 = JsonObject.mapFrom(poLines.get(2)).mapTo(CompositePoLine.class)
-      .withPaymentStatus(CompositePoLine.PaymentStatus.AWAITING_PAYMENT);
+    PoLine expectedPoLine1 = JsonObject.mapFrom(poLines.get(0)).mapTo(PoLine.class)
+        .withPaymentStatus(PoLine.PaymentStatus.PARTIALLY_PAID);
+    PoLine expectedPoLine2 = JsonObject.mapFrom(poLines.get(2)).mapTo(PoLine.class)
+      .withPaymentStatus(PoLine.PaymentStatus.AWAITING_PAYMENT);
     setupUpdatePoLinesQuery(List.of(expectedPoLine1, expectedPoLine2));
   }
 

--- a/src/test/java/org/folio/services/order/OrderLineServiceTest.java
+++ b/src/test/java/org/folio/services/order/OrderLineServiceTest.java
@@ -1,7 +1,6 @@
 package org.folio.services.order;
 
 import io.vertx.core.Future;
-import org.folio.rest.acq.model.orders.CompositePoLine;
 import org.folio.rest.acq.model.orders.PoLine;
 import org.folio.rest.acq.model.orders.PoLineCollection;
 import org.folio.rest.core.RestClient;
@@ -103,7 +102,7 @@ public class OrderLineServiceTest {
       .withId(UUID.randomUUID().toString());
     List<PoLine> poLines = List.of(poLine);
 
-    when(restClient.put(any(RequestEntry.class), any(CompositePoLine.class), eq(requestContext)))
+    when(restClient.put(any(RequestEntry.class), any(PoLine.class), eq(requestContext)))
       .thenReturn(Future.succeededFuture());
 
     Future<Void> result = orderLineService.updatePoLines(poLines, requestContext);

--- a/src/test/java/org/folio/services/order/OrderServiceTest.java
+++ b/src/test/java/org/folio/services/order/OrderServiceTest.java
@@ -21,7 +21,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.folio.HttpStatus;
 import org.folio.invoices.rest.exceptions.HttpException;
-import org.folio.rest.acq.model.orders.CompositePoLine;
 import org.folio.rest.acq.model.orders.OrderInvoiceRelationship;
 import org.folio.rest.acq.model.orders.OrderInvoiceRelationshipCollection;
 import org.folio.rest.acq.model.orders.PoLine;
@@ -64,12 +63,12 @@ public class OrderServiceTest {
     String invoiceId = UUID.randomUUID().toString();
     String poLineId = UUID.randomUUID().toString();
     String orderId = UUID.randomUUID().toString();
-    CompositePoLine poLine = new CompositePoLine().withId(poLineId).withPurchaseOrderId(orderId);
+    PoLine poLine = new PoLine().withId(poLineId).withPurchaseOrderId(orderId);
     OrderInvoiceRelationship relationship = new OrderInvoiceRelationship().withInvoiceId(invoiceId).withPurchaseOrderId(orderId);
     OrderInvoiceRelationshipCollection relationships = new OrderInvoiceRelationshipCollection().withOrderInvoiceRelationships(List.of(relationship)).withTotalRecords(1);
 
 
-    doReturn(succeededFuture(poLine)).when(restClient).get(any(RequestEntry.class), eq(CompositePoLine.class), eq(requestContextMock));
+    doReturn(succeededFuture(poLine)).when(restClient).get(any(RequestEntry.class), eq(PoLine.class), eq(requestContextMock));
     doReturn(succeededFuture(relationships)).when(restClient).get(any(RequestEntry.class), eq(OrderInvoiceRelationshipCollection.class), eq(requestContextMock));
     doReturn(succeededFuture(null)).when(restClient).delete(any(RequestEntry.class), eq(requestContextMock));
     doReturn(succeededFuture(poLine)).when(orderLineService).getPoLineById(poLineId, requestContextMock);
@@ -88,11 +87,11 @@ public class OrderServiceTest {
     String invoiceId = UUID.randomUUID().toString();
     String poLineId = UUID.randomUUID().toString();
     String orderId = UUID.randomUUID().toString();
-    CompositePoLine poLine = new CompositePoLine().withId(poLineId).withPurchaseOrderId(orderId);
+    PoLine poLine = new PoLine().withId(poLineId).withPurchaseOrderId(orderId);
     OrderInvoiceRelationshipCollection relationships = new OrderInvoiceRelationshipCollection().withOrderInvoiceRelationships(Collections.EMPTY_LIST).withTotalRecords(0);
 
 
-    doReturn(succeededFuture(poLine)).when(restClient).get(any(RequestEntry.class), eq(CompositePoLine.class), eq(requestContextMock));
+    doReturn(succeededFuture(poLine)).when(restClient).get(any(RequestEntry.class), eq(PoLine.class), eq(requestContextMock));
     doReturn(succeededFuture(relationships)).when(restClient).get(any(RequestEntry.class), eq(OrderInvoiceRelationshipCollection.class), eq(requestContextMock));
 
     doReturn(succeededFuture(poLine)).when(orderLineService).getPoLineById(poLineId, requestContextMock);
@@ -144,7 +143,7 @@ public class OrderServiceTest {
   void shouldRethrowUserNotAMemberOfTheAcqWhenUpdatePoLine(VertxTestContext vertxTestContext) {
     // given
     doReturn(failedFuture(new HttpException(HttpStatus.HTTP_FORBIDDEN.toInt(), USER_NOT_A_MEMBER_OF_THE_ACQ.toError())))
-      .when(restClient).put(any(RequestEntry.class), any(CompositePoLine.class), eq(requestContextMock));
+      .when(restClient).put(any(RequestEntry.class), any(PoLine.class), eq(requestContextMock));
 
     // when
     Future<Void> future = orderLineServiceInject.updatePoLines(List.of(new PoLine()), requestContextMock);
@@ -168,10 +167,10 @@ public class OrderServiceTest {
   void shouldRethrowUserNotAMemberOfTheAcqWhenGetPoLine(VertxTestContext vertxTestContext) {
     // given
     doReturn(failedFuture(new HttpException(HttpStatus.HTTP_FORBIDDEN.toInt(), USER_NOT_A_MEMBER_OF_THE_ACQ.toError())))
-      .when(restClient).get(any(RequestEntry.class), eq(CompositePoLine.class), eq(requestContextMock));
+      .when(restClient).get(any(RequestEntry.class), eq(PoLine.class), eq(requestContextMock));
 
     // when
-    Future<CompositePoLine> future = orderLineServiceInject.getPoLineById("id", requestContextMock);
+    Future<PoLine> future = orderLineServiceInject.getPoLineById("id", requestContextMock);
 
     // then
     vertxTestContext.assertFailure(future)

--- a/src/test/resources/mockdata/compositeOrders/0cb6741d-4a00-47e5-a902-5678eb24478d.json
+++ b/src/test/resources/mockdata/compositeOrders/0cb6741d-4a00-47e5-a902-5678eb24478d.json
@@ -13,7 +13,7 @@
   "reEncumber": false,
   "vendor": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Pending",
-  "compositePoLines": [
+  "poLines": [
     {
       "id": "2bafc9e1-9dd3-4ede-9f23-c4a03f8bb2d5",
       "purchaseOrderId" : "0cb6741d-4a00-47e5-a902-5678eb24478d",

--- a/src/test/resources/mockdata/compositeOrders/201a7028-df56-11eb-ba80-0242ac130004.json
+++ b/src/test/resources/mockdata/compositeOrders/201a7028-df56-11eb-ba80-0242ac130004.json
@@ -13,7 +13,7 @@
   "reEncumber": false,
   "vendor": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Pending",
-  "compositePoLines": [
+  "poLines": [
     {
       "id": "5b10de9c-df56-11eb-ba80-0242ac130004",
       "purchaseOrderId" : "201a7028-df56-11eb-ba80-0242ac130004",

--- a/src/test/resources/mockdata/compositeOrders/443bcf4c-41e9-4a07-8e70-dcc71ca56069.json
+++ b/src/test/resources/mockdata/compositeOrders/443bcf4c-41e9-4a07-8e70-dcc71ca56069.json
@@ -8,7 +8,6 @@
     "poLineEstimatedPrice": 1.0
   },
   "rush": false,
-  "alerts": [],
   "claims": [],
   "source": "User",
   "details": {
@@ -51,7 +50,6 @@
   "paymentStatus": "Payment Not Required",
   "receiptStatus": "Awaiting Receipt",
   "claimingActive": false,
-  "reportingCodes": [],
   "titleOrPackage": "Test 7",
   "automaticExport": false,
   "purchaseOrderId": "65842f8e-b90d-44bb-a233-d750e5757510",

--- a/src/test/resources/mockdata/compositeOrders/e9496a5c-84d1-4f95-89ad-a764be51ca29.json
+++ b/src/test/resources/mockdata/compositeOrders/e9496a5c-84d1-4f95-89ad-a764be51ca29.json
@@ -8,7 +8,6 @@
     "poLineEstimatedPrice": 1.0
   },
   "rush": false,
-  "alerts": [],
   "claims": [],
   "source": "User",
   "details": {
@@ -51,7 +50,6 @@
   "paymentStatus": "Awaiting Payment",
   "receiptStatus": "Awaiting Receipt",
   "claimingActive": false,
-  "reportingCodes": [],
   "titleOrPackage": "Test 8",
   "automaticExport": false,
   "purchaseOrderId": "9fe04405-fc1b-4dbc-b1ed-4fa26fb0d667",

--- a/src/test/resources/mockdata/poLines/0000edd1-b463-41ba-bf64-1b1d9f9d0001.json
+++ b/src/test/resources/mockdata/poLines/0000edd1-b463-41ba-bf64-1b1d9f9d0001.json
@@ -2,7 +2,6 @@
   "id": "0000edd1-b463-41ba-bf64-1b1d9f9d0001",
   "purchaseOrderId" : "0cb6741d-4a00-47e5-a902-5678eb24478d",
   "checkinItems": false,
-  "alerts": [],
   "claims": [],
   "collection": false,
   "contributors": [],
@@ -20,7 +19,6 @@
   "paymentStatus": "Pending",
   "poLineNumber": "010170-01",
   "receiptStatus": "Pending",
-  "reportingCodes": [],
   "rush": false,
   "titleOrPackage": "polTitle-1",
   "vendorDetail": {

--- a/src/test/resources/mockdata/poLines/0000edd1-b463-41ba-bf64-1b1d9f9d0003.json
+++ b/src/test/resources/mockdata/poLines/0000edd1-b463-41ba-bf64-1b1d9f9d0003.json
@@ -2,7 +2,6 @@
   "id": "0000edd1-b463-41ba-bf64-1b1d9f9d0003",
   "purchaseOrderId" : "0cb6741d-4a00-47e5-a902-5678eb24478d",
   "checkinItems": false,
-  "alerts": [],
   "claims": [],
   "collection": false,
   "contributors": [],
@@ -29,7 +28,6 @@
   "paymentStatus": "Pending",
   "poLineNumber": "010170-03",
   "receiptStatus": "Pending",
-  "reportingCodes": [],
   "rush": false,
   "titleOrPackage": "polTitle-3",
   "vendorDetail": {

--- a/src/test/resources/mockdata/poLines/0009662b-8b80-4001-b704-ca10971f175d.json
+++ b/src/test/resources/mockdata/poLines/0009662b-8b80-4001-b704-ca10971f175d.json
@@ -1,7 +1,6 @@
 {
   "id": "0009662b-8b80-4001-b704-ca10971f175d",
   "acquisitionMethod": "df26d81b-9d63-4ff8-bf41-49bf75cfa70e",
-  "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
   "claims": [
@@ -68,7 +67,6 @@
   "purchaseOrderId": "95d29d04-34b1-4fe0-a15e-1cd129143692",
   "receiptDate": null,
   "receiptStatus": "Pending",
-  "reportingCodes": [],
   "requester": "",
   "rush": false,
   "selector": "",

--- a/src/test/resources/mockdata/poLines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
+++ b/src/test/resources/mockdata/poLines/c2755a78-2f8d-47d0-a218-059a9b7391b4.json
@@ -1,7 +1,6 @@
 {
   "id": "c2755a78-2f8d-47d0-a218-059a9b7391b4",
   "acquisitionMethod": "df26d81b-9d63-4ff8-bf41-49bf75cfa70e",
-  "alerts": [],
   "cancellationRestriction": false,
   "cancellationRestrictionNote": "",
   "claims": [
@@ -66,7 +65,6 @@
   "purchaseOrderId": "3419ed01-a339-4448-9539-9815f231d405",
   "receiptDate": null,
   "receiptStatus": "Fully Received",
-  "reportingCodes": [],
   "requester": "",
   "rush": false,
   "selector": "Woods",


### PR DESCRIPTION
## Purpose
[MODORDERS-1269](https://folio-org.atlassian.net/browse/MODORDERS-1269) - Remove alerts and reporting codes from order lines, use a single order line schema

## Approach
- Removed alerts and reporting codes
- Use a single po line schema, no more "composite po line"

## Related PRs
- See [mod-orders-storage](https://github.com/folio-org/mod-orders-storage/pull/477)
- Required for compilation: [acq-models](https://github.com/folio-org/acq-models/pull/520)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate action.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code are 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
