### PR TITLE
[MODINVOICE-579-2]. Fully disable Java Money Moneta's inbuilt external providers

### DIFF
--- a/src/main/resources/javamoney.properties
+++ b/src/main/resources/javamoney.properties
@@ -1,4 +1,31 @@
 # Standard provider chain
-# disable all builtin conversion providers for the app
-{1}conversion.default-chain=
+# disable all builtin conversion providers except IDENT that always return exchange rate of 1
+{1}conversion.default-chain=IDENT
 
+# Disable ECBCurrentRateProvider
+{1}load.ECBCurrentRateProvider.type=NEVER
+{1}load.ECBCurrentRateProvider.startRemote=false
+{1}load.ECBCurrentRateProvider.resource=org/javamoney/moneta/convert/ecb/defaults/eurofxref-daily.xml
+{1}load.ECBCurrentRateProvider.urls=
+
+# Disable ECBHistoric90RateProvider
+{1}load.ECBHistoric90RateProvider.type=NEVER
+{1}load.ECBHistoric90RateProvider.startRemote=false
+{1}load.ECBHistoric90RateProvider.resource=org/javamoney/moneta/convert/ecb/defaults/eurofxref-hist-90d.xml
+{1}load.ECBHistoric90RateProvider.urls=
+
+# Disable ECBHistoricRateProvider
+{1}load.ECBHistoricRateProvider.type=NEVER
+{1}load.ECBHistoricRateProvider.startRemote=false
+{1}load.ECBHistoricRateProvider.resource=org/javamoney/moneta/convert/ecb/defaults/eurofxref-hist.xml
+{1}load.ECBHistoricRateProvider.urls=
+
+# Disable IMFHistoricRateProvider
+{1}load.IMFRateProvider.type=NEVER
+{1}load.IMFRateProvider.startRemote=false
+{1}load.IMFRateProvider.urls=
+
+# Disable IMFHistoricRateProvider
+{1}load.IMFHistoricRateProvider.type=NEVER
+{1}load.IMFHistoricRateProvider.startRemote=false
+{1}load.IMFHistoricRateProvider.urls=


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODINVOICE-579>

## Approach

- Fully disable Java Money Moneta's inbuilt external providers by setting `urls` to empty string and `type` set to **NEVER**
- Add an `IDENT` provider back to the chain to avoid silent exceptions on service startup