### PR TITLE
MODINVOICE-592: data-import-processing-core 4.4.3 fixing GraalVM vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <mod-di-converter-storage-client.version>2.3.1</mod-di-converter-storage-client.version>
     <folio-di-support.version>3.0.0</folio-di-support.version>
     <folio-kafka-wrapper.version>3.3.0</folio-kafka-wrapper.version>
-    <data-import-processing-core.version>4.4.0</data-import-processing-core.version>
+    <data-import-processing-core.version>4.4.3</data-import-processing-core.version>
 
     <!--Maven plugin dependencies-->
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODINVOICE-592

## Purpose
Upgrade data-import-processing-core from 4.4.0 to 4.4.3, this indirectly upgrades transitive dependency GraalVM js fixing security vulnerabilities:

* CVE-2025-21587 – https://github.com/advisories/GHSA-7f6c-8chx-2vm5 – GraalVM timing attack
* CVE-2025-30691 – https://github.com/advisories/GHSA-qh4r-w9x4-6fq2 – GraalVM buffer overflow
* CVE-2025-30698 – https://github.com/advisories/GHSA-3fvx-r9r8-xq97 – GraalVM heap-based boffer overflow

## Approach
Bump patch version of data-import-processing-core from 4.4.0 to 4.4.3 in pom.xml.

#### TODOS and Open Questions
- [x] Check logging.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate action.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code are 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.