### PR TITLE
MODINV-1246: Prevent XXE, disable external access JAXBContextWrapper

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 6.1.0 - Unreleased
+* [MODINV-1246](https://folio-org.atlassian.net/browse/MODINV-1246) - Prevent XXE, disable external access in JAXBContextWrapper SchemaFactory
 
 ## 6.0.0 - Released (Sunflower R1 2025)
 The focus of this release was to implement improvements and do version upgrades.

--- a/src/main/java/org/folio/jaxb/JAXBContextWrapper.java
+++ b/src/main/java/org/folio/jaxb/JAXBContextWrapper.java
@@ -6,6 +6,7 @@ import static javax.xml.bind.Marshaller.JAXB_FORMATTED_OUTPUT;
 import java.io.File;
 import java.util.List;
 
+import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
@@ -62,7 +63,12 @@ public final class JAXBContextWrapper {
     final String SCHEMA_PATH = "ramls" + File.separator + "schemas" + File.separator;
     List<StreamSource> streamSourceList = JAXBUtil.xsdSchemasAsStreamResources(SCHEMA_PATH, schemas);
     StreamSource[] streamSources = new StreamSource[streamSourceList.size()];
-    return SchemaFactory.newInstance(W3C_XML_SCHEMA_NS_URI)
-      .newSchema(streamSourceList.toArray(streamSources));
+    var schemaFactory = SchemaFactory.newInstance(W3C_XML_SCHEMA_NS_URI);
+    // prevent XML external entity injection (XXE)
+    // https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#schemafactory
+    // https://semgrep.dev/docs/cheat-sheets/java-xxe#3g-schemafactory
+    schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    return schemaFactory.newSchema(streamSourceList.toArray(streamSources));
   }
 }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODINV-1246

## Purpose
Prevent XML external entity injection (XXE), disable external access in JAXBContextWrapper SchemaFactory:

* https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#schemafactory
* https://semgrep.dev/docs/cheat-sheets/java-xxe#3g-schemafactory

## Approach
Disable ACCESS_EXTERNAL_DTD and ACCESS_EXTERNAL_SCHEMA.

#### TODOS and Open Questions
- [x] Check logging.

## Learning
When processing XML pay attention to XXE.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate action.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code are 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.