### PR TITLE
MODINVOICE-601. Voucher export dates have changed from human-readable timestamp to epoch long format (Sunflower)

### DIFF
--- a/src/main/java/org/folio/services/voucher/BatchVoucherService.java
+++ b/src/main/java/org/folio/services/voucher/BatchVoucherService.java
@@ -9,10 +9,10 @@ import static org.folio.invoices.utils.ResourcePathResolver.resourcesPath;
 import javax.xml.stream.XMLStreamException;
 
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.converters.BatchVoucherModelConverter;
+import org.folio.dbschema.ObjectMapperTool;
 import org.folio.invoices.rest.exceptions.HttpException;
 import org.folio.jaxb.XMLConverter;
 import org.folio.rest.core.RestClient;
@@ -44,7 +44,7 @@ public class BatchVoucherService {
 
   public String convertBatchVoucher(BatchVoucher batchVoucher, String contentType) {
     if (contentType.equalsIgnoreCase(APPLICATION_JSON)){
-      return JsonObject.mapFrom(batchVoucher).encodePrettily();
+      return ObjectMapperTool.valueAsString(batchVoucher);
     }
     if (contentType.equalsIgnoreCase(APPLICATION_XML)) {
       BatchVoucherType xmlBatchVoucher = batchVoucherModelConverter.convert(batchVoucher);

--- a/src/test/java/org/folio/rest/impl/BatchVoucherImplTest.java
+++ b/src/test/java/org/folio/rest/impl/BatchVoucherImplTest.java
@@ -3,6 +3,9 @@ package org.folio.rest.impl;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -13,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.restassured.http.Headers;
 import io.restassured.response.Response;
+import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 
 @ExtendWith(VertxExtension.class)
@@ -28,18 +32,23 @@ public class BatchVoucherImplTest extends ApiTestBase {
   private static final String BATCH_VOUCHER_SAMPLE_PATH = BATCH_VOUCHER_MOCK_DATA_PATH + VALID_BATCH_VOUCHER_ID + ".json";
   public static final String NON_EXISTING_BATCH_VOUCHER_ID = "12345678-83b9-4760-9c39-b58dcd02ee16";
 
+  // ISO 8601 date format pattern (e.g., "2019-12-07T00:01:04.000+00:00")
+  private static final Pattern ISO_DATE_PATTERN = Pattern.compile(
+    "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}[+-]\\d{2}:\\d{2}"
+  );
+
   @Test
   public void testGetJSONShouldReturnBatchVoucherInById() {
-    logger.info("=== Test Get Batch voucher by Id - 404 Not found ===");
-      final Response resp = verifyGet(String.format(BATCH_VOUCHER_ID_PATH, VALID_BATCH_VOUCHER_ID)
-        , Headers.headers(ACCEPT_JSON_HEADER, X_OKAPI_TENANT), APPLICATION_JSON, 200);
-      String actual = resp.getBody()
-        .as(BatchVoucher.class)
-        .getId();
-      logger.info("Id found: " + actual);
+    logger.info("=== Test Get Batch voucher by Id - JSON format with date validation ===");
+    final Response resp = verifyGet(String.format(BATCH_VOUCHER_ID_PATH, VALID_BATCH_VOUCHER_ID),
+      Headers.headers(ACCEPT_JSON_HEADER, X_OKAPI_TENANT), APPLICATION_JSON, 200);
 
-      assertEquals(VALID_BATCH_VOUCHER_ID, actual);
-      assertAllFieldsExistAndEqual(getMockAsJson(BATCH_VOUCHER_SAMPLE_PATH), resp);
+    BatchVoucher batchVoucher = resp.getBody().as(BatchVoucher.class);
+    String actual = batchVoucher.getId();
+
+    assertEquals(VALID_BATCH_VOUCHER_ID, actual);
+    assertAllFieldsExistAndEqual(getMockAsJson(BATCH_VOUCHER_SAMPLE_PATH), resp);
+    assertValidDateFormats(resp);
   }
 
   @Test
@@ -67,5 +76,37 @@ public class BatchVoucherImplTest extends ApiTestBase {
     logger.info("=== Test Get Batch voucher by Id - 404 Bad request ===");
     verifyGet(String.format(BATCH_VOUCHER_ID_PATH, NON_EXISTING_BATCH_VOUCHER_ID)
       , Headers.headers(ACCEPT_JSON_HEADER, X_OKAPI_TENANT), APPLICATION_JSON, 404);
+  }
+
+  private void assertValidDateFormats(Response resp) {
+    String plainJson = resp.getBody().asString();
+    JsonObject properDateJson = new JsonObject(plainJson);
+
+    // Check that date fields are in ISO format, not epoch
+    validateDateFormat(properDateJson.getString("created"), "created");
+    validateDateFormat(properDateJson.getString("start"), "start");
+    validateDateFormat(properDateJson.getString("end"), "end");
+
+    // Check voucher dates within batchedVouchers array
+    JsonObject firstVoucher = properDateJson.getJsonArray("batchedVouchers").getJsonObject(0);
+    validateDateFormat(firstVoucher.getString("disbursementDate"), "disbursementDate");
+    validateDateFormat(firstVoucher.getString("invoiceDate"), "invoiceDate");
+    validateDateFormat(firstVoucher.getString("voucherDate"), "voucherDate");
+  }
+
+  /**
+   * Validates that a date string is in proper ISO 8601 format and not in epoch format
+   */
+  private void validateDateFormat(String dateString, String fieldName) {
+    assertTrue(ISO_DATE_PATTERN.matcher(dateString).matches(),
+      "Field '" + fieldName + "' should be in ISO format but was: " + dateString);
+
+    // Additional check: ensure it's not a long number (epoch format)
+    try {
+      Long.parseLong(dateString);
+      throw new AssertionError("Field '" + fieldName + "' appears to be in epoch format: " + dateString);
+    } catch (NumberFormatException e) {
+      // This is expected - the date should not be parseable as a long
+    }
   }
 }


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MODINVOICE-601

### **Approach**
Use correct json mapper as mentioned in the ticket description

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
