### PR TITLE
[MODINVOICE-604] Introduce internal Settings API and migrate voucher number prefixes

### DIFF
--- a/src/main/java/org/folio/invoices/utils/ResourcePathResolver.java
+++ b/src/main/java/org/folio/invoices/utils/ResourcePathResolver.java
@@ -38,8 +38,8 @@ public class ResourcePathResolver {
   public static final String EXPENSE_CLASSES_URL = "expenseClassUrl";
   public static final String BUDGET_EXPENSE_CLASSES = "finance-storage.budget-expense-classes";
   public static final String FINANCE_EXCHANGE_RATE = "finance/exchange-rate";
-  public static final String CONFIGURATION_ENTRIES = "configurations/entries";
   public static final String SETTINGS_ENTRIES = "settings/entries";
+  public static final String INVOICE_STORAGE_SETTINGS = "invoice/settings";
   public static final String FISCAL_YEARS = "fiscalYears";
   public static final String EXCHANGE_RATE = "exchangeRate";
 
@@ -76,8 +76,8 @@ public class ResourcePathResolver {
     apis.put(BUDGET_EXPENSE_CLASSES, "/finance-storage/budget-expense-classes");
     apis.put(EXPENSE_CLASSES_URL, "/finance/expense-classes");
     apis.put(FINANCE_EXCHANGE_RATE, "/finance/exchange-rate");
-    apis.put(CONFIGURATION_ENTRIES, "/configurations/entries");
     apis.put(SETTINGS_ENTRIES, "/settings/entries");
+    apis.put(INVOICE_STORAGE_SETTINGS, "/invoice-storage/settings");
     apis.put(FISCAL_YEARS, "/finance/fiscal-years");
     apis.put(EXCHANGE_RATE, "/finance/exchange-rate");
 

--- a/src/main/java/org/folio/services/settings/CommonSettingsService.java
+++ b/src/main/java/org/folio/services/settings/CommonSettingsService.java
@@ -6,14 +6,14 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.folio.rest.acq.model.Setting;
+import org.folio.rest.acq.model.SettingCollection;
 import org.folio.rest.acq.model.settings.CommonSetting;
 import org.folio.rest.acq.model.settings.CommonSettingsCollection;
 import org.folio.rest.acq.model.settings.Value;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
-import org.folio.rest.jaxrs.model.Config;
-import org.folio.rest.jaxrs.model.Configs;
 import org.springframework.stereotype.Service;
 
 import io.vertx.core.Future;
@@ -27,64 +27,43 @@ import one.util.streamex.StreamEx;
 @RequiredArgsConstructor
 public class CommonSettingsService {
 
-  public static final String VOUCHER_NUMBER_PREFIX_CONFIG_QUERY = "(module==INVOICE and configName==voucherNumber)";
-  public static final String VOUCHER_NUMBER_PREFIX_KEY = "voucherNumberPrefix";
+  public static final String VOUCHER_NUMBER_PREFIX_KEY = "USD";
 
-  public static final String SETTINGS_QUERY = "(scope==stripes-core.prefs.manage and key==tenantLocaleSettings)";
-  public static final String TENANT_LOCALE_SETTINGS = "tenantLocaleSettings";
   public static final String CURRENCY_KEY = "currency";
   public static final String CURRENCY_DEFAULT = "USD";
 
   private final RestClient restClient;
 
   /**
-   * Get voucher number prefix via config from the deprecated <code>mod-configurations</code>
+   * Get voucher number prefix via config from the internal <code>mod-invoice-storage</code> settings table
    *
    * @param requestContext the request context
    * @return a future containing the voucher number prefix if it exists, otherwise an empty string
    */
   public Future<String> getVoucherNumberPrefix(RequestEntry requestEntry, RequestContext requestContext) {
-    return restClient.get(requestEntry, Configs.class, requestContext)
-      .map(configs -> StreamEx.of(configs.getConfigs())
-        .map(Config::getValue)
+    return restClient.get(requestEntry, SettingCollection.class, requestContext)
+      .map(settingCollection -> StreamEx.of(settingCollection.getSettings())
+        .map(Setting::getValue)
         .nonNull()
         .map(value -> new JsonObject(value).getString(VOUCHER_NUMBER_PREFIX_KEY))
         .findFirst(StringUtils::isNotBlank)
         .orElse(EMPTY));
   }
 
-  /**
-   * Get system currency via tenant locale settings from <code>mod-settings</code>.
-   *
-   * @param requestEntry the request entry
-   * @param requestContext the request context
-   * @return a future containing the currency if it exists, otherwise the default currency
-   */
   public Future<String> getSystemCurrency(RequestEntry requestEntry, RequestContext requestContext) {
-    return loadTenantLocaleSetting(CURRENCY_KEY, CURRENCY_DEFAULT, requestEntry, requestContext);
+    return getGlobalSetting(CURRENCY_KEY, CURRENCY_DEFAULT, requestEntry, requestContext);
   }
 
-  /**
-   * Load tenant locale settings from <code>mod-settings</code>.
-   *
-   * @param requestEntry the request entry
-   * @param requestContext the request context
-   * @return a future containing the list of common settings
-   */
-  public Future<List<CommonSetting>> loadSettings(RequestEntry requestEntry, RequestContext requestContext) {
+  private Future<String> getGlobalSetting(String key, String defaultValue, RequestEntry requestEntry, RequestContext requestContext) {
     return restClient.get(requestEntry, CommonSettingsCollection.class, requestContext)
-      .map(settingsCollection -> Optional.ofNullable(settingsCollection.getItems()).orElse(List.of()));
-  }
-
-  private Future<String> loadTenantLocaleSetting(String key, String defaultValue, RequestEntry requestEntry, RequestContext requestContext) {
-    return loadSettings(requestEntry, requestContext).map(settings -> settings.stream()
-      .filter(setting -> TENANT_LOCALE_SETTINGS.equals(setting.getKey()))
-      .findFirst()
-      .map(CommonSetting::getValue)
-      .map(Value::getAdditionalProperties)
-      .map(properties -> properties.get(key))
-      .map(Object::toString)
-      .orElse(defaultValue));
+      .map(settingsCollection -> Optional.ofNullable(settingsCollection.getItems()).orElse(List.of()))
+      .map(settings -> settings.stream()
+        .findFirst()
+        .map(CommonSetting::getValue)
+        .map(Value::getAdditionalProperties)
+        .map(properties -> properties.get(key))
+        .map(Object::toString)
+        .orElse(defaultValue));
   }
 
 }


### PR DESCRIPTION
### **Purpose**
[[MODINVOICE-604] Introduce internal Settings API and migrate voucher number prefixes](https://folio-org.atlassian.net/browse/MODINVOICE-604)

### **Approach**
- Refactor cache and settings service to fetch voucher number from the invoice-storage

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
