### PR TITLE
MODDATAIMP-1225 - Change dependency on `data-import-converter-storage` interface to optional

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 6.1.0 - Unreleased
 * [MODINV-1246](https://folio-org.atlassian.net/browse/MODINV-1246) - Prevent XXE, disable external access in JAXBContextWrapper SchemaFactory
+* [MODDATAIMP-1225](https://folio-org.atlassian.net/browse/MODDATAIMP-1225) - Change dependency on `data-import-converter-storage` interface to optional
 
 ## 6.0.0 - Released (Sunflower R1 2025)
 The focus of this release was to implement improvements and do version upgrades.

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -683,16 +683,16 @@
     {
       "id" : "orders-storage.order-invoice-relationships",
       "version": "1.0"
-    },
-    {
-      "id": "data-import-converter-storage",
-      "version": "1.4"
     }
   ],
   "optional": [
     {
       "id": "orders",
       "version": "13.0"
+    },
+    {
+      "id": "data-import-converter-storage",
+      "version": "1.4"
     }
   ],
   "permissionSets": [


### PR DESCRIPTION
## Purpose
The mod-di-converter-storage module is being extracted from the app-platform-complete application to the app-data-import application. To avoid making the `app-acquisition` application dependent on `app-data-import`, the dependency on `data-import-converter-storage` interface should be changed to optional.




## Learning
[MODDATAIMP-1225](https://issues.folio.org/browse/MODDATAIMP-1225)