### PR TITLE
[MODORDERS-1439] Cancel invoice: update po line statuses before unreleasing encumbrances

### DIFF
--- a/src/main/java/org/folio/services/invoice/InvoiceCancelService.java
+++ b/src/main/java/org/folio/services/invoice/InvoiceCancelService.java
@@ -108,7 +108,7 @@ public class InvoiceCancelService {
       .compose(v -> cancelVoucher(invoiceId, requestContext))
       .compose(v -> poLinePaymentStatusUpdateService.updatePoLinePaymentStatusToCancelInvoice(invoiceFromStorage,
         lines, poLinePaymentStatus, requestContext))
-      .compose(v -> vertx.timer(50)) // wait for order to have a chance to reopen automatically
+      .compose(v -> vertx.timer(200)) // wait for order to have a chance to reopen automatically
       .compose(v -> updateOrUnreleaseEncumbrances(lines, invoiceFromStorage, requestContext))
       .onSuccess(v -> log.info("cancelInvoice:: Invoice {} cancelled successfully", invoiceId))
       .onFailure(t -> log.error("cancelInvoice:: Failed to cancel invoice {}", invoiceId, t));

--- a/src/main/java/org/folio/services/invoice/InvoiceCancelService.java
+++ b/src/main/java/org/folio/services/invoice/InvoiceCancelService.java
@@ -108,8 +108,11 @@ public class InvoiceCancelService {
       .compose(v -> cancelVoucher(invoiceId, requestContext))
       .compose(v -> poLinePaymentStatusUpdateService.updatePoLinePaymentStatusToCancelInvoice(invoiceFromStorage,
         lines, poLinePaymentStatus, requestContext))
-      .compose(v -> vertx.timer(200)) // wait for order to have a chance to reopen automatically
-      .compose(v -> updateOrUnreleaseEncumbrances(lines, invoiceFromStorage, requestContext))
+      .onSuccess(v -> {
+        // Wait 1s for orders to reopen and unrelease encumbrances asynchronously
+        vertx.timer(1000)
+          .compose(v2 -> updateOrUnreleaseEncumbrances(lines, invoiceFromStorage, requestContext));
+      })
       .onSuccess(v -> log.info("cancelInvoice:: Invoice {} cancelled successfully", invoiceId))
       .onFailure(t -> log.error("cancelInvoice:: Failed to cancel invoice {}", invoiceId, t));
   }

--- a/src/main/java/org/folio/services/invoice/InvoiceCancelService.java
+++ b/src/main/java/org/folio/services/invoice/InvoiceCancelService.java
@@ -92,7 +92,7 @@ public class InvoiceCancelService {
                                     RequestContext requestContext) {
     String invoiceId = invoiceFromStorage.getId();
     log.info("cancelInvoice:: Cancelling invoice {}...", invoiceId);
-    Vertx vertx = Vertx.vertx();
+    Vertx vertx =  requestContext.getContext().owner();
     return Future.succeededFuture()
       .map(v -> {
         validateCancelInvoice(invoiceFromStorage);

--- a/src/main/java/org/folio/services/invoice/InvoiceCancelService.java
+++ b/src/main/java/org/folio/services/invoice/InvoiceCancelService.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Objects;
 
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 import lombok.extern.log4j.Log4j2;
 import org.folio.InvoiceWorkflowDataHolderBuilder;
 import org.folio.invoices.rest.exceptions.HttpException;
@@ -91,7 +92,7 @@ public class InvoiceCancelService {
                                     RequestContext requestContext) {
     String invoiceId = invoiceFromStorage.getId();
     log.info("cancelInvoice:: Cancelling invoice {}...", invoiceId);
-
+    Vertx vertx = Vertx.vertx();
     return Future.succeededFuture()
       .map(v -> {
         validateCancelInvoice(invoiceFromStorage);
@@ -105,9 +106,10 @@ public class InvoiceCancelService {
         return null;
       })
       .compose(v -> cancelVoucher(invoiceId, requestContext))
-      .compose(v -> updateOrUnreleaseEncumbrances(lines, invoiceFromStorage, requestContext))
       .compose(v -> poLinePaymentStatusUpdateService.updatePoLinePaymentStatusToCancelInvoice(invoiceFromStorage,
         lines, poLinePaymentStatus, requestContext))
+      .compose(v -> vertx.timer(50)) // wait for order to have a chance to reopen automatically
+      .compose(v -> updateOrUnreleaseEncumbrances(lines, invoiceFromStorage, requestContext))
       .onSuccess(v -> log.info("cancelInvoice:: Invoice {} cancelled successfully", invoiceId))
       .onFailure(t -> log.error("cancelInvoice:: Failed to cancel invoice {}", invoiceId, t));
   }

--- a/src/test/java/org/folio/services/invoice/InvoiceCancelServiceTest.java
+++ b/src/test/java/org/folio/services/invoice/InvoiceCancelServiceTest.java
@@ -285,19 +285,15 @@ public class InvoiceCancelServiceTest {
   }
 
   @Test
-  public void errorUnreleasingEncumbrances(VertxTestContext vertxTestContext) throws IOException {
+  public void noErrorReportedWhenUnreleaseEncumbrancesFails(VertxTestContext vertxTestContext) throws IOException {
     Invoice invoice = getMockAs(APPROVED_INVOICE_SAMPLE_PATH, Invoice.class);
     List<InvoiceLine> invoiceLines = getMockAs(INVOICE_LINES_LIST_PATH, InvoiceLineCollection.class).getInvoiceLines();
 
     setupRestCalls(invoice, false, true);
 
     Future<Void> future = cancelService.cancelInvoice(invoice, invoiceLines, null, requestContext);
-    vertxTestContext.assertFailure(future)
-      .onComplete(result -> {
-        HttpException httpException = (HttpException) result.cause();
-        assertEquals(500, httpException.getCode());
-        var error = httpException.getErrors().getErrors().getFirst();
-        assertEquals(ERROR_UNRELEASING_ENCUMBRANCES.getCode(), error.getCode());
+    vertxTestContext.assertComplete(future)
+      .onSuccess(result -> {
         vertxTestContext.completeNow();
       });
   }


### PR DESCRIPTION
## Purpose
[MODORDERS-1439](https://folio-org.atlassian.net/browse/MODORDERS-1439) - Cancelling an invoice does not update order correctly

## Approach
- When cancelling an invoice, update po line statuses before unreleasing encumbrances
- Wait for the order status to have a chance to update async after changing the po line statuses

## Related PRs
- [mod-orders](https://github.com/folio-org/mod-orders/pull/1291)
- [folio-integration-tests](https://github.com/folio-org/folio-integration-tests/pull/2295)

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
