### PR TITLE
[MODINVOICE-648]. "Sub total" and "Calculated total amount" missing from Invoice version history

### DIFF
--- a/src/main/java/org/folio/invoices/utils/InvoiceProtectedFields.java
+++ b/src/main/java/org/folio/invoices/utils/InvoiceProtectedFields.java
@@ -20,7 +20,9 @@ public enum InvoiceProtectedFields implements ProtectedField<Invoice> {
   VOUCHER_NUMBER("voucherNumber", Invoice::getVoucherNumber),
   PAYMENT_ID("paymentId", Invoice::getPaymentId),
   PO_NUMBERS("poNumbers", Invoice::getPoNumbers),
-  VENDOR_ID("vendorId", Invoice::getVendorId);
+  VENDOR_ID("vendorId", Invoice::getVendorId),
+  SUB_TOTAL("subTotal", Invoice::getSubTotal),
+  TOTAL("total", Invoice::getTotal);
 
   InvoiceProtectedFields(String field, Function<Invoice, Object> getter) {
     this.field = field;

--- a/src/test/java/org/folio/ApiTestSuite.java
+++ b/src/test/java/org/folio/ApiTestSuite.java
@@ -35,6 +35,7 @@ import org.folio.dataimport.handlers.events.DataImportKafkaHandlerTest;
 import org.folio.dataimport.handlers.actions.CreateInvoiceEventHandlerTest;
 import org.folio.invoices.util.HelperUtilsTest;
 import org.folio.jaxb.DefaultJAXBRootElementNameResolverTest;
+import org.folio.services.validator.InvoiceValidatorTest;
 import org.folio.utils.InvoiceLineUtilsTest;
 import org.folio.jaxb.JAXBUtilTest;
 import org.folio.jaxb.XMLConverterTest;
@@ -421,4 +422,7 @@ public class ApiTestSuite {
 
   @Nested
   class InvoiceLineUtilsTestNested extends InvoiceLineUtilsTest {}
+
+  @Nested
+  class InvoiceValidatorTestNested extends InvoiceValidatorTest {}
 }

--- a/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
+++ b/src/test/java/org/folio/rest/impl/InvoicesApiTest.java
@@ -3032,6 +3032,8 @@ public class InvoicesApiTest extends ApiTestBase {
     allProtectedFieldsModification.put(InvoiceProtectedFields.VOUCHER_NUMBER, "some_voucher_number");
     allProtectedFieldsModification.put(InvoiceProtectedFields.PAYMENT_ID, UUID.randomUUID().toString());
     allProtectedFieldsModification.put(InvoiceProtectedFields.VENDOR_ID, UUID.randomUUID().toString());
+    allProtectedFieldsModification.put(InvoiceProtectedFields.SUB_TOTAL, 99.99d);
+    allProtectedFieldsModification.put(InvoiceProtectedFields.TOTAL, 99.99d);
 
     List<String> poNumbers = invoice.getPoNumbers();
     poNumbers.addFirst("AB267798XYZ");

--- a/src/test/java/org/folio/services/validator/InvoiceValidatorTest.java
+++ b/src/test/java/org/folio/services/validator/InvoiceValidatorTest.java
@@ -1,0 +1,97 @@
+package org.folio.services.validator;
+
+import static org.folio.invoices.utils.ErrorCodes.PROHIBITED_FIELD_CHANGING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import org.folio.invoices.rest.exceptions.HttpException;
+import org.folio.rest.jaxrs.model.Invoice;
+import org.folio.services.adjusment.AdjustmentsService;
+import org.folio.services.finance.fiscalyear.FiscalYearService;
+import org.folio.services.order.OrderLineService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class InvoiceValidatorTest {
+
+  private InvoiceValidator validator;
+
+  @BeforeEach
+  void setUp() {
+    validator = new InvoiceValidator(
+      mock(AdjustmentsService.class),
+      mock(OrderLineService.class),
+      mock(FiscalYearService.class)
+    );
+  }
+
+  /** Creates a minimal approved invoice with the given subTotal and total. */
+  private Invoice approvedInvoice(double subTotal, double total) {
+    return new Invoice()
+      .withStatus(Invoice.Status.APPROVED)
+      .withSubTotal(subTotal)
+      .withTotal(total);
+  }
+
+  @Test
+  void validateInvoiceProtectedFields_throwsWhenSubTotalChanged() {
+    var stored  = approvedInvoice(10.00, 10.00);
+    var updated = approvedInvoice(99.99, 10.00); // subTotal changed
+
+    var ex = assertThrows(HttpException.class,
+      () -> validator.validateInvoiceProtectedFields(updated, stored));
+
+    assertEquals(400, ex.getCode());
+    assertEquals(PROHIBITED_FIELD_CHANGING.getCode(),
+      ex.getErrors().getErrors().getFirst().getCode());
+  }
+
+  @Test
+  void validateInvoiceProtectedFields_throwsWhenTotalChanged() {
+    var stored  = approvedInvoice(10.00, 10.00);
+    var updated = approvedInvoice(10.00, 99.99); // total changed
+
+    var ex = assertThrows(HttpException.class,
+      () -> validator.validateInvoiceProtectedFields(updated, stored));
+
+    assertEquals(400, ex.getCode());
+    assertEquals(PROHIBITED_FIELD_CHANGING.getCode(),
+      ex.getErrors().getErrors().getFirst().getCode());
+  }
+
+  @Test
+  void validateInvoiceProtectedFields_throwsWhenBothSubTotalAndTotalChanged() {
+    var stored  = approvedInvoice(10.00, 10.00);
+    var updated = approvedInvoice(50.00, 50.00);
+
+    var ex = assertThrows(HttpException.class,
+      () -> validator.validateInvoiceProtectedFields(updated, stored));
+
+    assertEquals(400, ex.getCode());
+    assertEquals(PROHIBITED_FIELD_CHANGING.getCode(),
+      ex.getErrors().getErrors().getFirst().getCode());
+  }
+
+  @Test
+  void validateInvoiceProtectedFields_doesNotThrowWhenSubTotalAndTotalUnchanged() {
+    var stored  = approvedInvoice(10.00, 12.50);
+    var updated = approvedInvoice(10.00, 12.50);
+
+    // Must not throw
+    validator.validateInvoiceProtectedFields(updated, stored);
+  }
+
+  @ParameterizedTest
+  @CsvSource({ "Open", "Reviewed" })
+  void validateInvoiceProtectedFields_doesNotThrowForPreApprovalStatuses(String storedStatusName) {
+    var storedStatus = Invoice.Status.fromValue(storedStatusName);
+    var stored  = new Invoice().withStatus(storedStatus).withSubTotal(10.00).withTotal(10.00);
+    var updated = new Invoice().withStatus(storedStatus).withSubTotal(99.99).withTotal(99.99);
+
+    // Pre-approval invoices are not protected — must not throw
+    validator.validateInvoiceProtectedFields(updated, stored);
+  }
+}


### PR DESCRIPTION
### **Purpose**

- <https://folio-org.atlassian.net/browse/MODINVOICE-648>

### **Approach**

- Update acq-models to remove `"readonly": true` property on both `subTotal` and `total`
- Add `subTotal` and `total` to field protection enum

> Invoice-level audit pane now correctly displays the newly changed totals

<img width="2554" height="1382" alt="image" src="https://github.com/user-attachments/assets/25d9823f-0d34-409a-9635-58bc6f7758bc" />
