### PR TITLE
[MODINVOICE-647] Protect nextInvoiceLineNumber

### DIFF
--- a/src/main/java/org/folio/invoices/utils/InvoiceProtectedFields.java
+++ b/src/main/java/org/folio/invoices/utils/InvoiceProtectedFields.java
@@ -22,7 +22,8 @@ public enum InvoiceProtectedFields implements ProtectedField<Invoice> {
   PO_NUMBERS("poNumbers", Invoice::getPoNumbers),
   VENDOR_ID("vendorId", Invoice::getVendorId),
   SUB_TOTAL("subTotal", Invoice::getSubTotal),
-  TOTAL("total", Invoice::getTotal);
+  TOTAL("total", Invoice::getTotal),
+  NEXT_INVOICE_LINE_NUMBER("nextInvoiceLineNumber", Invoice::getNextInvoiceLineNumber);
 
   InvoiceProtectedFields(String field, Function<Invoice, Object> getter) {
     this.field = field;


### PR DESCRIPTION
## Purpose
[MODINVOICE-647](https://folio-org.atlassian.net/browse/MODINVOICE-647) - Invoice line number is reused after deletion

## Approach
Added `nextInvoiceLineNumber` to the list of protected fields.

## Related PRs
- [acq-models 1](https://github.com/folio-org/acq-models/pull/567), [acq-models 2](https://github.com/folio-org/acq-models/pull/568)
- [mod-invoice-storage](https://github.com/folio-org/mod-invoice-storage/pull/259)
- [mod-orders-storage](https://github.com/folio-org/mod-orders-storage/pull/623)
- [mod-orders](https://github.com/folio-org/mod-orders/pull/1307)
- [folio-integration-tests](https://github.com/folio-org/folio-integration-tests/pull/2352)

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
