### PR TITLE
[MODINVOICE-647] Silently ignore changes to nextInvoiceLineNumber

### DIFF
--- a/src/main/java/org/folio/invoices/utils/InvoiceProtectedFields.java
+++ b/src/main/java/org/folio/invoices/utils/InvoiceProtectedFields.java
@@ -22,8 +22,7 @@ public enum InvoiceProtectedFields implements ProtectedField<Invoice> {
   PO_NUMBERS("poNumbers", Invoice::getPoNumbers),
   VENDOR_ID("vendorId", Invoice::getVendorId),
   SUB_TOTAL("subTotal", Invoice::getSubTotal),
-  TOTAL("total", Invoice::getTotal),
-  NEXT_INVOICE_LINE_NUMBER("nextInvoiceLineNumber", Invoice::getNextInvoiceLineNumber);
+  TOTAL("total", Invoice::getTotal);
 
   InvoiceProtectedFields(String field, Function<Invoice, Object> getter) {
     this.field = field;

--- a/src/main/java/org/folio/rest/impl/InvoiceHelper.java
+++ b/src/main/java/org/folio/rest/impl/InvoiceHelper.java
@@ -316,6 +316,7 @@ public class InvoiceHelper extends AbstractHelper {
 
   private Future<Void> validateAndHandleInvoiceStatusTransition(Invoice invoice, Invoice invoiceFromStorage,
                                                                 String poLinePaymentStatus) {
+    invoice.setNextInvoiceLineNumber(invoiceFromStorage.getNextInvoiceLineNumber()); // ignore any change of nextInvoiceLineNumber
     return validateAcqUnitsOnUpdate(invoice, invoiceFromStorage)
       .map(ok -> {
         validator.validateInvoice(invoice, invoiceFromStorage);


### PR DESCRIPTION
## Purpose
[MODINVOICE-647](https://folio-org.atlassian.net/browse/MODINVOICE-647) - Invoice line number is reused after deletion

## Approach
- Silently ignore changes to `nextInvoiceLineNumber` (protected fields are only protected after approval)

## Related PRs
- [mod-invoice](https://github.com/folio-org/mod-invoice/pull/622)
- and others

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
