### PR TITLE
MODINVOICE-652 - Data Import App Crashes when Loading Large EDI Files

### DIFF
--- a/src/main/java/org/folio/rest/core/RestClient.java
+++ b/src/main/java/org/folio/rest/core/RestClient.java
@@ -9,7 +9,6 @@ import static org.folio.rest.RestConstants.OKAPI_URL;
 import java.util.Map;
 
 import org.folio.invoices.rest.exceptions.HttpException;
-import org.folio.okapi.common.WebClientFactory;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
 
@@ -19,6 +18,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpResponseExpectation;
+import io.vertx.core.http.PoolOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
@@ -29,6 +29,9 @@ import lombok.extern.log4j.Log4j2;
 public class RestClient {
 
   private static final String REQUEST_MESSAGE_LOG_INFO = "Calling {} {}";
+  private static final String HTTP_POOL_MAX_SIZE_PROPERTY = "mod.invoice.restclient.pool.size";
+  private static final int HTTP_POOL_MAX_SIZE_DEFAULT = 10;
+  private static final int HTTP_POOL_MAX_SIZE = resolveHttpPoolSize();
 
   public <T> Future<T> post(RequestEntry requestEntry, T entity, Class<T> responseType, RequestContext requestContext) {
     return post(requestEntry.buildEndpoint(), entity, responseType, requestContext);
@@ -115,15 +118,16 @@ public class RestClient {
     return promise.future();
   }
 
-  private <T>void handleGetMethodErrorResponse(Promise<T> promise, Throwable t, boolean skipError404) {
+  private <T>void handleGetMethodErrorResponse(Promise<T> promise, Throwable t, boolean skipError404, String endpoint) {
     if (skipError404 && t instanceof HttpException && ((HttpException) t).getCode() == 404) {
       log.warn(t);
       promise.complete();
     } else {
-      log.error(t);
+      log.error("handleGetMethodErrorResponse:: failed to call GET {}", endpoint, t);
       promise.fail(t);
     }
   }
+
   private void handleErrorResponse(Promise<Void> promise, Throwable t, boolean skipError404) {
     if (skipError404 && t instanceof HttpException && ((HttpException) t).getCode() == 404){
       log.warn(t);
@@ -163,7 +167,7 @@ public class RestClient {
       .map(HttpResponse::bodyAsJsonObject)
       .map(jsonObject -> jsonObject.mapTo(responseType))
       .onSuccess(promise::complete)
-      .onFailure(t -> handleGetMethodErrorResponse(promise, t, skipError404));
+      .onFailure(t -> handleGetMethodErrorResponse(promise, t, skipError404, endpoint));
 
     return promise.future();
   }
@@ -180,7 +184,7 @@ public class RestClient {
       .compose(RestClient::convertHttpResponse)
       .map(HttpResponse::bodyAsJsonObject)
       .onSuccess(promise::complete)
-      .onFailure(t -> handleGetMethodErrorResponse(promise, t, false));
+      .onFailure(t -> handleGetMethodErrorResponse(promise, t, false, endpoint));
 
     return promise.future();
   }
@@ -201,12 +205,21 @@ public class RestClient {
     options.setKeepAlive(true);
     options.setConnectTimeout(2000);
     options.setIdleTimeout(5000);
-    return WebClientFactory.getWebClient(context.owner(), options);
+
+    PoolOptions poolOptions = new PoolOptions()
+      .setHttp1MaxSize(HTTP_POOL_MAX_SIZE);
+
+    return WebClientProvider.getWebClient(context.owner(), options, poolOptions);
   }
 
   protected static String buildAbsEndpoint(MultiMap okapiHeaders, String endpoint) {
     var okapiURL = okapiHeaders.get(OKAPI_URL);
     return okapiURL + endpoint;
+  }
+
+  private static int resolveHttpPoolSize() {
+    String poolSize = System.getProperty(HTTP_POOL_MAX_SIZE_PROPERTY, System.getenv(HTTP_POOL_MAX_SIZE_PROPERTY));
+    return poolSize != null ? Integer.parseInt(poolSize) : HTTP_POOL_MAX_SIZE_DEFAULT;
   }
 
 }

--- a/src/main/java/org/folio/rest/core/WebClientProvider.java
+++ b/src/main/java/org/folio/rest/core/WebClientProvider.java
@@ -1,0 +1,38 @@
+package org.folio.rest.core;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.PoolOptions;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Provides a cached {@link WebClient} instance per {@link Vertx} instance.
+ * The WebClient is created on the first call for a given Vertx instance and reused for all
+ * subsequent calls. The {@code options} and {@code poolOptions} parameters are only applied
+ * during initial creation; they are ignored if a WebClient already exists for the given
+ * Vertx instance.
+ */
+@UtilityClass
+public class WebClientProvider {
+
+  private static final Map<Vertx, WebClient> WEB_CLIENTS = new ConcurrentHashMap<>();
+
+  /**
+   * Returns a cached {@link WebClient} for the given {@link Vertx} instance.
+   * If no WebClient exists yet for the provided Vertx instance, a new one is created
+   * using the supplied {@code options} and {@code poolOptions}. Otherwise, the existing
+   * WebClient is returned and the {@code options} and {@code poolOptions} are ignored.
+   *
+   * @param vertx       the Vertx instance to associate the WebClient with
+   * @param options     the WebClient options (used only on first creation)
+   * @param poolOptions the connection pool options (used only on first creation)
+   * @return a cached WebClient instance
+   */
+  public static WebClient getWebClient(Vertx vertx, WebClientOptions options, PoolOptions poolOptions) {
+    return WEB_CLIENTS.computeIfAbsent(vertx, v -> WebClient.create(v, options, poolOptions));
+  }
+}

--- a/src/test/java/org/folio/ApiTestSuite.java
+++ b/src/test/java/org/folio/ApiTestSuite.java
@@ -35,6 +35,7 @@ import org.folio.dataimport.handlers.events.DataImportKafkaHandlerTest;
 import org.folio.dataimport.handlers.actions.CreateInvoiceEventHandlerTest;
 import org.folio.invoices.util.HelperUtilsTest;
 import org.folio.jaxb.DefaultJAXBRootElementNameResolverTest;
+import org.folio.rest.core.WebClientProviderTest;
 import org.folio.utils.InvoiceLineUtilsTest;
 import org.folio.jaxb.JAXBUtilTest;
 import org.folio.jaxb.XMLConverterTest;
@@ -421,4 +422,7 @@ public class ApiTestSuite {
 
   @Nested
   class InvoiceLineUtilsTestNested extends InvoiceLineUtilsTest {}
+
+  @Nested
+  class WebClientProviderTestNested extends WebClientProviderTest {}
 }

--- a/src/test/java/org/folio/rest/core/WebClientProviderTest.java
+++ b/src/test/java/org/folio/rest/core/WebClientProviderTest.java
@@ -1,0 +1,58 @@
+package org.folio.rest.core;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.PoolOptions;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.junit5.VertxExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(VertxExtension.class)
+public class WebClientProviderTest {
+
+  @Test
+  void shouldReturnNonNullWebClient(Vertx vertx) {
+    var options = new WebClientOptions();
+    var poolOptions = new PoolOptions();
+
+    var client = WebClientProvider.getWebClient(vertx, options, poolOptions);
+
+    assertNotNull(client);
+  }
+
+  @Test
+  void shouldReturnSameInstanceForSameVertx(Vertx vertx) {
+    var options = new WebClientOptions();
+    var poolOptions = new PoolOptions();
+
+    var client1 = WebClientProvider.getWebClient(vertx, options, poolOptions);
+    var client2 = WebClientProvider.getWebClient(vertx, options, poolOptions);
+
+    assertSame(client1, client2);
+  }
+
+  @Test
+  void shouldReturnDifferentInstancesForDifferentVertx() {
+    var vertx1 = Vertx.vertx();
+    var vertx2 = Vertx.vertx();
+
+    try {
+      var options = new WebClientOptions();
+      var poolOptions = new PoolOptions();
+
+      var client1 = WebClientProvider.getWebClient(vertx1, options, poolOptions);
+      var client2 = WebClientProvider.getWebClient(vertx2, options, poolOptions);
+
+      assertNotNull(client1);
+      assertNotNull(client2);
+      assertNotSame(client1, client2);
+    } finally {
+      vertx1.close();
+      vertx2.close();
+    }
+  }
+}


### PR DESCRIPTION
## Purpose
During invoice import, "Connection closed" error occurs for arbitrary invoice lines during the processing of regular logic for invoice line creation. This occurs when mod-invoice manages to make 5 calls to mod-orders API to get purchase order by id,
causing a deadlock situation to occur.

The requests chain when deadlock occurs is as follows:
1. mod-invoice -> mod-orders  (mod-invoice performs 5 requests to mod-orders to get order by id, utilizing all available connections in WebClient)
2. mod-invoice <- mod-orders  (mod-orders to process requests from step 1. calls mod-invoice to get several invoices)
3. mod-invoice -> mod-invoice-storage (mod-invoice to process request from step 2. needs to call mod-invoice-storage to fetch invoices from there but gets stuck waiting for free connections on WebClient until eventually sidecars close connections).

The approach proposes to increase the maximum possible pool size for WebClient to 10 (by default pool size is 5) to prevent deadlock occurrence between modules, without reducing the throughput of processing data import events by mod-invoice. Additionally, to provide a configuration parameter for configuration flexibility.
The WebClient pool has timeout configuration (60 seconds by default) after which it closes unused connections in the pool.
In this way, 10 idle connections will not be kept open indefinitely, thereby helping in managing resources.


## Approach
* Added WebClientProvider utility class that caches a WebClient per Vertx instance, bypassing okapi-common library WebClientFactory, which does not allow to configure pool size during WebClient creation.
* The default connection pool size has been increased from the default 5 to 10. 
Also, the "mod.invoice.restclient.pool.size" configuration parameter has been added, just in case, to provide configuration flexibility. The "mod.invoice.restclient.pool.size" configuration parameter can be resolved from either system properties or environment variables, respectively.
* Added tests


## Learning
[MODINVOICE-652](https://issues.folio.org/browse/MODINVOICE-652)