### PR TITLE
Trillium release v6.1.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+## 6.1.3 - Released (Trillium R1 2026 Bug Fix)
+The primary focus of this release was to fix issue with encumbrance processing for PO lines with a single fund distribution and multiple expense classes.
+
+[Full Changelog](https://github.com/folio-org/mod-invoice/compare/v6.1.2...v6.1.3)
+
+### Bug Fixes
+* [MODINVOICE-654](https://folio-org.atlassian.net/browse/MODINVOICE-654) - Encumbrance is not processed for PO lines with a single fund distribution and multiple expense classes
+
 ## 6.1.2 - Released (Trillium R1 2026 Bug Fix)
 The primary focus of this release was to fix "Connection closed" error issue during EDIFACT file import
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-invoice</artifactId>
-  <version>6.1.3-SNAPSHOT</version>
+  <version>6.1.3</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -811,7 +811,7 @@
     <url>https://github.com/folio-org/mod-invoice</url>
     <connection>scm:git:git://github.com/folio-org/mod-invoice</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-invoice.git</developerConnection>
-    <tag>v6.1.0</tag>
+    <tag>v6.1.3</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-invoice</artifactId>
-  <version>6.1.3</version>
+  <version>6.1.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -811,7 +811,7 @@
     <url>https://github.com/folio-org/mod-invoice</url>
     <connection>scm:git:git://github.com/folio-org/mod-invoice</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-invoice.git</developerConnection>
-    <tag>v6.1.3</tag>
+    <tag>v6.1.0</tag>
   </scm>
 
   <repositories>

--- a/src/main/java/org/folio/services/finance/transaction/EncumbranceService.java
+++ b/src/main/java/org/folio/services/finance/transaction/EncumbranceService.java
@@ -7,9 +7,10 @@ import static org.folio.invoices.utils.HelperUtils.convertIdsToCqlQuery;
 import static org.folio.rest.RestConstants.MAX_IDS_FOR_GET_RQ;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -98,13 +99,12 @@ public class EncumbranceService {
 
   private List<InvoiceLine> updateFundDistributionsWithEncumbrances(List<InvoiceWorkflowDataHolder> holders,
                                                                     List<Transaction> encumbrances) {
+    Map<InvoiceWorkflowDataHolder, Transaction> matched = matchEncumbrancesToHolders(holders, encumbrances);
     var linesToUpdate = new ArrayList<InvoiceLine>();
     for (InvoiceWorkflowDataHolder holder : holders) {
-      var matchingEncumbrances = encumbrances.stream()
-        .filter(enc -> shouldChangeFundDistributions(holder, enc))
-        .collect(Collectors.toCollection(ArrayList::new));
       var fundDistribution = holder.getFundDistribution();
-      if (matchingEncumbrances.isEmpty()) {
+      var encumbrance = matched.get(holder);
+      if (encumbrance == null) {
         if (fundDistribution.getEncumbrance() != null) {
           fundDistribution.withEncumbrance(null);
           holder.withEncumbrance(null);
@@ -112,24 +112,47 @@ public class EncumbranceService {
             linesToUpdate.add(holder.getInvoiceLine());
           }
         }
-      } else {
-        var encumbrance = matchingEncumbrances.getFirst();
-        if (!encumbrance.getId().equals(fundDistribution.getEncumbrance())) {
-          fundDistribution.withEncumbrance(encumbrance.getId());
-          holder.withEncumbrance(encumbrance);
-          if (!linesToUpdate.contains(holder.getInvoiceLine())) {
-            linesToUpdate.add(holder.getInvoiceLine());
-          }
+      } else if (!encumbrance.getId().equals(fundDistribution.getEncumbrance())) {
+        fundDistribution.withEncumbrance(encumbrance.getId());
+        holder.withEncumbrance(encumbrance);
+        if (!linesToUpdate.contains(holder.getInvoiceLine())) {
+          linesToUpdate.add(holder.getInvoiceLine());
         }
       }
     }
     return linesToUpdate;
   }
 
-  private boolean shouldChangeFundDistributions(InvoiceWorkflowDataHolder holder, Transaction enc) {
-    var isMatchPoLineId = enc.getEncumbrance().getSourcePoLineId().equals(holder.getInvoiceLine().getPoLineId());
-    var isMatchFundId = enc.getFromFundId().equals(holder.getFundId());
-    logger.info("shouldChangeFundDistributions:: Matching poLineId={}, fundId={}", isMatchPoLineId, isMatchFundId);
-    return isMatchPoLineId && isMatchFundId;
+  private Map<InvoiceWorkflowDataHolder, Transaction> matchEncumbrancesToHolders(List<InvoiceWorkflowDataHolder> holders,
+                                                                                 List<Transaction> encumbrances) {
+    Map<InvoiceWorkflowDataHolder, Transaction> matched = new HashMap<>();
+
+    // Pass 1: pair each holder with the encumbrance matching fund AND expense class.
+    for (InvoiceWorkflowDataHolder holder : holders) {
+      encumbrances.stream()
+        .filter(enc -> matchesPoLineAndFund(holder, enc))
+        .filter(enc -> Objects.equals(enc.getExpenseClassId(), holder.getFundDistribution().getExpenseClassId()))
+        .findFirst()
+        .ifPresent(enc -> matched.put(holder, enc));
+    }
+
+    // Pass 2: fallback on fund only (handles POLs whose expense class was changed
+    // without updating the invoice line).
+    for (InvoiceWorkflowDataHolder holder : holders) {
+      if (matched.containsKey(holder)) {
+        continue;
+      }
+      encumbrances.stream()
+        .filter(enc -> matchesPoLineAndFund(holder, enc))
+        .findFirst()
+        .ifPresent(enc -> matched.put(holder, enc));
+    }
+
+    return matched;
+  }
+
+  private boolean matchesPoLineAndFund(InvoiceWorkflowDataHolder holder, Transaction enc) {
+    return enc.getEncumbrance().getSourcePoLineId().equals(holder.getInvoiceLine().getPoLineId())
+      && enc.getFromFundId().equals(holder.getFundId());
   }
 }

--- a/src/test/java/org/folio/services/finance/transaction/EncumbranceServiceTest.java
+++ b/src/test/java/org/folio/services/finance/transaction/EncumbranceServiceTest.java
@@ -241,6 +241,93 @@ public class EncumbranceServiceTest {
   }
 
   @Test
+  @DisplayName("link a distinct encumbrance to each FD when a PO line has multiple expense classes on the same fund")
+  void shouldMatchEncumbrancesPerExpenseClassWhenSameFund(VertxTestContext vertxTestContext) {
+    String fiscalYearId = UUID.randomUUID().toString();
+    String poLineId = UUID.randomUUID().toString();
+    String fundId = UUID.randomUUID().toString();
+    String expenseClassA = UUID.randomUUID().toString();
+    String expenseClassB = UUID.randomUUID().toString();
+
+    Transaction encA = new Transaction()
+      .withId(UUID.randomUUID().toString())
+      .withFiscalYearId(fiscalYearId)
+      .withFromFundId(fundId)
+      .withExpenseClassId(expenseClassA)
+      .withEncumbrance(new Encumbrance().withSourcePoLineId(poLineId));
+    Transaction encB = new Transaction()
+      .withId(UUID.randomUUID().toString())
+      .withFiscalYearId(fiscalYearId)
+      .withFromFundId(fundId)
+      .withExpenseClassId(expenseClassB)
+      .withEncumbrance(new Encumbrance().withSourcePoLineId(poLineId));
+
+    FundDistribution fdA = new FundDistribution().withFundId(fundId).withExpenseClassId(expenseClassA);
+    FundDistribution fdB = new FundDistribution().withFundId(fundId).withExpenseClassId(expenseClassB);
+    InvoiceLine line = new InvoiceLine().withPoLineId(poLineId).withFundDistributions(List.of(fdA, fdB));
+    InvoiceWorkflowDataHolder holderA = new InvoiceWorkflowDataHolder().withInvoiceLine(line).withFundDistribution(fdA);
+    InvoiceWorkflowDataHolder holderB = new InvoiceWorkflowDataHolder().withInvoiceLine(line).withFundDistribution(fdB);
+
+    TransactionCollection transactionCollection = new TransactionCollection()
+      .withTotalRecords(2)
+      .withTransactions(List.of(encB, encA));
+    when(restClient.get(any(RequestEntry.class), any(), eq(requestContext)))
+      .thenReturn(Future.succeededFuture(transactionCollection));
+
+    Future<List<InvoiceLine>> future = encumbranceService.updateInvoiceLinesEncumbranceLinks(
+      List.of(holderA, holderB), fiscalYearId, requestContext);
+
+    vertxTestContext.assertComplete(future)
+      .onComplete(ar -> {
+        assertEquals(encA.getId(), fdA.getEncumbrance());
+        assertEquals(encB.getId(), fdB.getEncumbrance());
+        assertEquals(encA, holderA.getEncumbrance());
+        assertEquals(encB, holderB.getEncumbrance());
+        vertxTestContext.completeNow();
+      });
+  }
+
+  @Test
+  @DisplayName("fall back to fund-only match when invoice line FD expense class no longer matches any encumbrance")
+  void shouldFallBackToFundMatchWhenExpenseClassChangedOnlyInPol(VertxTestContext vertxTestContext) {
+    String fiscalYearId = UUID.randomUUID().toString();
+    String poLineId = UUID.randomUUID().toString();
+    String fundId = UUID.randomUUID().toString();
+    String oldExpenseClass = UUID.randomUUID().toString();
+    String newExpenseClass = UUID.randomUUID().toString();
+
+    Transaction encumbrance = new Transaction()
+      .withId(UUID.randomUUID().toString())
+      .withFiscalYearId(fiscalYearId)
+      .withFromFundId(fundId)
+      .withExpenseClassId(newExpenseClass)
+      .withEncumbrance(new Encumbrance().withSourcePoLineId(poLineId));
+
+    FundDistribution fd = new FundDistribution()
+      .withFundId(fundId)
+      .withExpenseClassId(oldExpenseClass)
+      .withEncumbrance(UUID.randomUUID().toString());
+    InvoiceLine line = new InvoiceLine().withPoLineId(poLineId).withFundDistributions(List.of(fd));
+    InvoiceWorkflowDataHolder holder = new InvoiceWorkflowDataHolder().withInvoiceLine(line).withFundDistribution(fd);
+
+    TransactionCollection transactionCollection = new TransactionCollection()
+      .withTotalRecords(1)
+      .withTransactions(List.of(encumbrance));
+    when(restClient.get(any(RequestEntry.class), any(), eq(requestContext)))
+      .thenReturn(Future.succeededFuture(transactionCollection));
+
+    Future<List<InvoiceLine>> future = encumbranceService.updateInvoiceLinesEncumbranceLinks(
+      List.of(holder), fiscalYearId, requestContext);
+
+    vertxTestContext.assertComplete(future)
+      .onComplete(ar -> {
+        assertEquals(encumbrance.getId(), fd.getEncumbrance());
+        assertEquals(encumbrance, holder.getEncumbrance());
+        vertxTestContext.completeNow();
+      });
+  }
+
+  @Test
   @CopilotGenerated(model = "Claude Sonnet 4")
   @DisplayName("remove duplicate poLineIds when getting encumbrances")
   void shouldRemoveDuplicatePoLineIdsWhenGettingEncumbrances(VertxTestContext vertxTestContext) {


### PR DESCRIPTION
## 6.1.3 - Released (Trillium R1 2026 Bug Fix)
The primary focus of this release was to fix issue with encumbrance processing for PO lines with a single fund distribution and multiple expense classes.

[Full Changelog](https://github.com/folio-org/mod-invoice/compare/v6.1.2...v6.1.3)

### Bug Fixes
* [MODINVOICE-654](https://folio-org.atlassian.net/browse/MODINVOICE-654) - Encumbrance is not processed for PO lines with a single fund distribution and multiple expense classes