### PR TITLE
[MODINVOICE-657] Resolve issues with dependantbot upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,22 +27,22 @@
 
     <!--Dependencies-->
     <raml-module-builder.version>36.0.0</raml-module-builder.version>
-    <spring.version>7.0.6</spring.version>
+    <spring.version>7.0.8</spring.version>
     <jaxb-api.version>2.3.3</jaxb-api.version>
-    <vertx.version>5.0.12</vertx.version>
-    <vertx-rx.version>4.5.25</vertx-rx.version> <!-- Update to match vertx version when 5.x is available -->
+    <vertx.version>5.1.2</vertx.version>
+    <vertx-rx.version>4.5.28</vertx-rx.version> <!-- Update to match vertx version when 5.x is available -->
     <rest-assured.version>6.0.0</rest-assured.version>
-    <sshd.version>2.17.1</sshd.version>
+    <sshd.version>2.18.0</sshd.version>
     <assertj-core.version>3.27.7</assertj-core.version>
     <aspectj.version>1.9.25.1</aspectj.version>
-    <log4j.version>2.25.3</log4j.version>
+    <log4j.version>2.26.0</log4j.version>
     <streamex.version>0.8.4</streamex.version>
-    <caffeine.version>3.2.3</caffeine.version>
+    <caffeine.version>3.2.4</caffeine.version>
 
     <!--Folio dependencies properties-->
     <folio-module-descriptor-validator.version>1.0.1</folio-module-descriptor-validator.version>
-    <mod-configuration-client.version>5.12.1</mod-configuration-client.version>
-    <mod-di-converter-storage-client.version>2.4.3</mod-di-converter-storage-client.version>
+    <mod-configuration-client.version>5.13.0</mod-configuration-client.version>
+    <mod-di-converter-storage-client.version>2.5.0</mod-di-converter-storage-client.version>
     <folio-di-support.version>4.0.0</folio-di-support.version>
     <folio-kafka-wrapper.version>4.1.0-SNAPSHOT</folio-kafka-wrapper.version>
     <data-import-processing-core.version>5.0.0</data-import-processing-core.version>
@@ -60,10 +60,10 @@
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
 
     <!--Test dependencies-->
-    <testcontainers.version>2.0.3</testcontainers.version>
+    <testcontainers.version>2.0.5</testcontainers.version>
     <awaitility.version>4.3.0</awaitility.version>
     <mockito.version>5.23.0</mockito.version>
-    <junit-bom.version>6.0.3</junit-bom.version>
+    <junit-bom.version>6.1.0</junit-bom.version>
 
     <!--Sonar exclusions-->
     <sonar.exclusions>**/models/*.java</sonar.exclusions>
@@ -177,7 +177,7 @@
     <dependency>
       <groupId>commons-net</groupId>
       <artifactId>commons-net</artifactId>
-      <version>3.12.0</version>
+      <version>3.13.0</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>

--- a/src/test/java/org/folio/rest/impl/DocumentsApiTest.java
+++ b/src/test/java/org/folio/rest/impl/DocumentsApiTest.java
@@ -31,7 +31,6 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
@@ -78,7 +77,6 @@ public class DocumentsApiTest extends ApiTestBase {
       fail(context.causeOfFailure());
     }
   }
-
 
 
   @Test
@@ -146,7 +144,7 @@ public class DocumentsApiTest extends ApiTestBase {
     context.verify(() -> {
       assertEquals(201, response.statusCode());
       assertNotNull(response.headers().get(CONTENT_TYPE));
-      assertEquals(1 , MockServer.serverRqRs.get(INVOICE_DOCUMENTS, HttpMethod.POST).size());
+      assertEquals(1, MockServer.serverRqRs.get(INVOICE_DOCUMENTS, HttpMethod.POST).size());
       assertNotNull(new JsonObject(response.body()).mapTo(InvoiceDocument.class).getDocumentMetadata().getId());
     });
     context.completeNow();
@@ -173,7 +171,7 @@ public class DocumentsApiTest extends ApiTestBase {
 
   private void prepareRequestHeaders(HttpRequest<Buffer> request) {
 
-    MultiMap headers = HeadersMultiMap.httpHeaders();
+    MultiMap headers = MultiMap.caseInsensitiveMultiMap();
     headers.add(X_OKAPI_URL.getName(), X_OKAPI_URL.getValue())
             .add(X_OKAPI_TENANT.getName(), X_OKAPI_TENANT.getValue())
             .add(X_OKAPI_TOKEN.getName(), X_OKAPI_TOKEN.getValue())


### PR DESCRIPTION
### **Purpose**
[MODINVOICE-657](https://folio-org.atlassian.net/browse/MODINVOICE-657) - Resolve issues with dependantbot upgrades

### **Approach**
One API fix caused by a breaking change in Vert.x 5.1.x. `HeadersMultiMap.httpHeaders()` replaced with the public API `MultiMap.caseInsensitiveMultiMap()`

### **Related PR**
Dependabot PR that caused the failures - https://github.com/folio-org/mod-invoice/pull/630


### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
